### PR TITLE
Add abstract event base classes and aggregated events infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,12 @@
 - PHP 7.4 minimum compatibility
 - Tests: PHPUnit + Brain Monkey in `Tests/Unit/`
 - Text domain: `sybgo`
+
+## Post-implementation workflow (autonomous)
+
+After completing any non-trivial code change, always run the following steps without waiting to be asked:
+
+1. **Create a feature branch** — `git checkout -b feat/<short-name>` (or `fix/`, `chore/` as appropriate). Commit code changes and documentation changes in separate commits.
+2. **Run `/documentation`** — update `lib/docs/` and/or `wp-plugin/docs/` to reflect the changes on the current branch.
+3. **Run `/open_pr`** — create a PR against `develop` with the fully-filled WP Media template.
+4. **Run `/dod`** — verify all 5 Definition of Done checks pass. Fix any blockers before stopping.

--- a/lib/Tests/Unit/Database/AggregatedEventRepositoryTest.php
+++ b/lib/Tests/Unit/Database/AggregatedEventRepositoryTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Aggregated Event Repository Unit Tests
+ *
+ * @package Sybgo\Tests\Unit\Database
+ */
+
+namespace Sybgo\Tests\Unit\Database;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Database\Aggregated_Event_Repository;
+
+/**
+ * Aggregated Event Repository Test Case
+ */
+class AggregatedEventRepositoryTest extends TestCase {
+
+	/**
+	 * Repository instance.
+	 *
+	 * @var Aggregated_Event_Repository
+	 */
+	private $repo;
+
+	/**
+	 * Mock wpdb instance.
+	 *
+	 * @var Mockery\MockInterface
+	 */
+	private $wpdb;
+
+	/**
+	 * Set up test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->wpdb         = Mockery::mock( '\wpdb' );
+		$this->wpdb->prefix = 'wp_';
+		$GLOBALS['wpdb']    = $this->wpdb;
+
+		$this->repo = new Aggregated_Event_Repository( 'wp_sybgo_aggregated_events' );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test upsert_count() returns true on success.
+	 */
+	public function test_upsert_count_returns_true_on_success() {
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb
+			->shouldReceive( 'query' )
+			->once()
+			->with( 'PREPARED SQL' )
+			->andReturn( 1 );
+
+		$result = $this->repo->upsert_count( 'page_view', '2026-03-08' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test upsert_count() returns false when query fails.
+	 */
+	public function test_upsert_count_returns_false_on_failure() {
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb
+			->shouldReceive( 'query' )
+			->once()
+			->andReturn( false );
+
+		$result = $this->repo->upsert_count( 'page_view', '2026-03-08' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test upsert_count() passes event_type and date to prepare().
+	 */
+	public function test_upsert_count_passes_correct_arguments_to_prepare() {
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				Mockery::type( 'string' ),
+				'login_attempt',
+				'2026-03-08',
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' )
+			)
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb
+			->shouldReceive( 'query' )
+			->once()
+			->andReturn( 1 );
+
+		$this->repo->upsert_count( 'login_attempt', '2026-03-08' );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test upsert_count() with empty meta uses empty JSON object.
+	 */
+	public function test_upsert_count_with_empty_meta() {
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' ),
+				'[]',
+				'[]'
+			)
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb
+			->shouldReceive( 'query' )
+			->once()
+			->andReturn( 1 );
+
+		$this->repo->upsert_count( 'page_view', '2026-03-08' );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test upsert_count() with meta passes JSON-encoded meta.
+	 */
+	public function test_upsert_count_with_meta() {
+		$meta      = array( 'source' => 'homepage' );
+		$meta_json = json_encode( $meta );
+
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' ),
+				$meta_json,
+				$meta_json
+			)
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb
+			->shouldReceive( 'query' )
+			->once()
+			->andReturn( 1 );
+
+		$this->repo->upsert_count( 'page_view', '2026-03-08', $meta );
+
+		$this->addToAssertionCount( 1 );
+	}
+}

--- a/lib/Tests/Unit/Database/AggregatedEventRepositoryTest.php
+++ b/lib/Tests/Unit/Database/AggregatedEventRepositoryTest.php
@@ -45,7 +45,11 @@ class AggregatedEventRepositoryTest extends TestCase {
 
 		$this->repo = new Aggregated_Event_Repository( 'wp_sybgo_aggregated_events' );
 
-		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'wp_json_encode' )->alias(
+			function ( $data, int $flags = 0 ) {
+				return json_encode( $data, $flags );
+			}
+		);
 	}
 
 	/**
@@ -58,101 +62,110 @@ class AggregatedEventRepositoryTest extends TestCase {
 	}
 
 	/**
-	 * Test upsert_count() returns true on success.
+	 * Test upsert() returns true on success.
 	 */
-	public function test_upsert_count_returns_true_on_success() {
-		$this->wpdb
-			->shouldReceive( 'prepare' )
-			->once()
-			->andReturn( 'PREPARED SQL' );
+	public function test_upsert_returns_true_on_success() {
+		$this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'PREPARED SQL' );
+		$this->wpdb->shouldReceive( 'query' )->once()->with( 'PREPARED SQL' )->andReturn( 1 );
 
-		$this->wpdb
-			->shouldReceive( 'query' )
-			->once()
-			->with( 'PREPARED SQL' )
-			->andReturn( 1 );
-
-		$result = $this->repo->upsert_count( 'page_view', '2026-03-08' );
+		$result = $this->repo->upsert( 'page_view', '2026-03-08' );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Test upsert_count() returns false when query fails.
+	 * Test upsert() returns false when query fails.
 	 */
-	public function test_upsert_count_returns_false_on_failure() {
-		$this->wpdb
-			->shouldReceive( 'prepare' )
-			->once()
-			->andReturn( 'PREPARED SQL' );
+	public function test_upsert_returns_false_on_failure() {
+		$this->wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'PREPARED SQL' );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( false );
 
-		$this->wpdb
-			->shouldReceive( 'query' )
-			->once()
-			->andReturn( false );
-
-		$result = $this->repo->upsert_count( 'page_view', '2026-03-08' );
+		$result = $this->repo->upsert( 'page_view', '2026-03-08' );
 
 		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Test upsert_count() passes event_type and date to prepare().
+	 * Test upsert() passes event_type, date, and value to prepare().
 	 */
-	public function test_upsert_count_passes_correct_arguments_to_prepare() {
+	public function test_upsert_passes_event_type_date_value_to_prepare() {
 		$this->wpdb
 			->shouldReceive( 'prepare' )
 			->once()
 			->with(
 				Mockery::type( 'string' ),
-				'login_attempt',
+				'woo_sale_revenue',
+				Mockery::type( 'string' ), // dimensions JSON
+				249.95,
 				'2026-03-08',
+				Mockery::type( 'string' )  // meta JSON
+			)
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$this->repo->upsert( 'woo_sale_revenue', '2026-03-08', 249.95 );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test upsert() with empty dimensions encodes as '{}' (empty JSON object).
+	 */
+	public function test_upsert_with_empty_dimensions_encodes_as_empty_json_object() {
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				Mockery::type( 'string' ),
+				Mockery::type( 'string' ), // event_type
+				'{}',                      // empty dimensions → '{}'
+				Mockery::type( 'float' ),
 				Mockery::type( 'string' ),
 				Mockery::type( 'string' )
 			)
 			->andReturn( 'PREPARED SQL' );
 
-		$this->wpdb
-			->shouldReceive( 'query' )
-			->once()
-			->andReturn( 1 );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
 
-		$this->repo->upsert_count( 'login_attempt', '2026-03-08' );
+		$this->repo->upsert( 'page_view', '2026-03-08' );
 
 		$this->addToAssertionCount( 1 );
 	}
 
 	/**
-	 * Test upsert_count() with empty meta uses empty JSON object.
+	 * Test upsert() sorts dimension keys alphabetically for canonical JSON.
 	 */
-	public function test_upsert_count_with_empty_meta() {
+	public function test_upsert_sorts_dimension_keys_canonically() {
+		// Pass keys in reverse order; expect them sorted alphabetically.
+		$dimensions          = array( 'role' => 'editor', 'product_id' => 99 );
+		$expected_dimensions = '{"product_id":99,"role":"editor"}';
+
 		$this->wpdb
 			->shouldReceive( 'prepare' )
 			->once()
 			->with(
 				Mockery::type( 'string' ),
 				Mockery::type( 'string' ),
+				$expected_dimensions,
+				Mockery::type( 'float' ),
 				Mockery::type( 'string' ),
-				'[]',
-				'[]'
+				Mockery::type( 'string' )
 			)
 			->andReturn( 'PREPARED SQL' );
 
-		$this->wpdb
-			->shouldReceive( 'query' )
-			->once()
-			->andReturn( 1 );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
 
-		$this->repo->upsert_count( 'page_view', '2026-03-08' );
+		$this->repo->upsert( 'user_registered', '2026-03-08', 1.0, $dimensions );
 
 		$this->addToAssertionCount( 1 );
 	}
 
 	/**
-	 * Test upsert_count() with meta passes JSON-encoded meta.
+	 * Test upsert() with meta passes JSON-encoded meta.
 	 */
-	public function test_upsert_count_with_meta() {
-		$meta      = array( 'source' => 'homepage' );
+	public function test_upsert_with_meta_passes_json_encoded_meta() {
+		$meta      = array( 'product_name' => 'Widget' );
 		$meta_json = json_encode( $meta );
 
 		$this->wpdb
@@ -162,18 +175,48 @@ class AggregatedEventRepositoryTest extends TestCase {
 				Mockery::type( 'string' ),
 				Mockery::type( 'string' ),
 				Mockery::type( 'string' ),
-				$meta_json,
+				Mockery::type( 'float' ),
+				Mockery::type( 'string' ),
 				$meta_json
 			)
 			->andReturn( 'PREPARED SQL' );
 
-		$this->wpdb
-			->shouldReceive( 'query' )
-			->once()
-			->andReturn( 1 );
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
 
-		$this->repo->upsert_count( 'page_view', '2026-03-08', $meta );
+		$this->repo->upsert( 'woo_sale_units', '2026-03-08', 1.0, array(), $meta );
 
 		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test upsert() SQL uses value accumulation, not a fixed count increment.
+	 */
+	public function test_upsert_sql_accumulates_value() {
+		$captured_sql = '';
+
+		$this->wpdb
+			->shouldReceive( 'prepare' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $sql ) use ( &$captured_sql ) {
+						$captured_sql = $sql;
+						return true;
+					}
+				),
+				Mockery::any(),
+				Mockery::any(),
+				Mockery::any(),
+				Mockery::any(),
+				Mockery::any()
+			)
+			->andReturn( 'PREPARED SQL' );
+
+		$this->wpdb->shouldReceive( 'query' )->once()->andReturn( 1 );
+
+		$this->repo->upsert( 'page_view', '2026-03-08' );
+
+		$this->assertStringContainsString( 'value = value + VALUES(value)', $captured_sql );
+		$this->assertStringNotContainsString( 'count = count + 1', $captured_sql );
 	}
 }

--- a/lib/Tests/Unit/Events/AbstractSingularEventTest.php
+++ b/lib/Tests/Unit/Events/AbstractSingularEventTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Abstract Singular Event Unit Tests
+ *
+ * @package Sybgo\Tests\Unit\Events
+ */
+
+namespace Sybgo\Tests\Unit\Events;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Events\Abstracts\Abstract_Singular_Event;
+
+/**
+ * Concrete test double for Abstract_Singular_Event.
+ */
+class Concrete_Singular_Event extends Abstract_Singular_Event {
+	public function register_hooks(): void {}
+
+	public function register_event_types( array $types ): array {
+		return $types;
+	}
+
+	/**
+	 * Expose record() publicly for testing.
+	 *
+	 * @param string               $event_type Event type.
+	 * @param array<string, mixed> $event_data Event data.
+	 * @param string               $source     Source plugin.
+	 */
+	public function test_record( string $event_type, array $event_data, string $source = 'core' ): void {
+		$this->record( $event_type, $event_data, $source );
+	}
+
+	/**
+	 * Expose is_throttled() publicly for testing.
+	 *
+	 * @param string $event_type Event type.
+	 * @param int    $object_id  Object ID.
+	 * @param int    $seconds    Throttle window.
+	 */
+	public function test_is_throttled( string $event_type, int $object_id, int $seconds ): bool {
+		return $this->is_throttled( $event_type, $object_id, $seconds );
+	}
+}
+
+/**
+ * Abstract Singular Event Test Case
+ */
+class AbstractSingularEventTest extends TestCase {
+
+	/**
+	 * Concrete event instance.
+	 *
+	 * @var Concrete_Singular_Event
+	 */
+	private $event;
+
+	/**
+	 * Mock event repository.
+	 *
+	 * @var Mockery\MockInterface
+	 */
+	private $event_repo;
+
+	/**
+	 * Set up test environment.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->event_repo = Mockery::mock( 'Sybgo\Database\Event_Repository' );
+		$this->event      = new Concrete_Singular_Event( $this->event_repo );
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test record() calls event_repo->create() with the correct data.
+	 */
+	public function test_record_calls_create() {
+		$event_data = array( 'action' => 'published' );
+
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		Functions\when( 'do_action' )->justReturn( null );
+
+		$this->event_repo
+			->shouldReceive( 'create' )
+			->once()
+			->with( Mockery::on( function ( $args ) use ( $event_data ) {
+				$this->assertSame( 'post_published', $args['event_type'] );
+				$this->assertSame( $event_data, $args['event_data'] );
+				$this->assertSame( 'core', $args['source_plugin'] );
+				return true;
+			} ) )
+			->andReturn( 1 );
+
+		$this->event->test_record( 'post_published', $event_data );
+	}
+
+	/**
+	 * Test record() with custom source plugin.
+	 */
+	public function test_record_with_custom_source() {
+		$event_data = array( 'action' => 'custom' );
+
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+		Functions\when( 'do_action' )->justReturn( null );
+
+		$this->event_repo
+			->shouldReceive( 'create' )
+			->once()
+			->with( Mockery::on( function ( $args ) {
+				$this->assertSame( 'my-plugin', $args['source_plugin'] );
+				return true;
+			} ) )
+			->andReturn( 1 );
+
+		$this->event->test_record( 'custom_event', $event_data, 'my-plugin' );
+	}
+
+	/**
+	 * Test record() fires sybgo_event_recorded action after creation.
+	 */
+	public function test_record_fires_event_recorded_action() {
+		$event_data = array( 'action' => 'published' );
+
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$this->event_repo
+			->shouldReceive( 'create' )
+			->once()
+			->andReturn( 42 );
+
+		Actions\expectDone( 'sybgo_event_recorded' )
+			->once()
+			->with( 42, 'post_published', Mockery::any() );
+
+		$this->event->test_record( 'post_published', $event_data );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test record() skips create when sybgo_should_track_event returns false.
+	 */
+	public function test_record_skips_when_should_not_track() {
+		$event_data = array( 'action' => 'published' );
+
+		Functions\when( 'apply_filters' )->alias( function( $tag, $value ) {
+			if ( 'sybgo_should_track_event' === $tag ) {
+				return false;
+			}
+			return $value;
+		} );
+
+		$this->event_repo->shouldNotReceive( 'create' );
+
+		$this->event->test_record( 'post_published', $event_data );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test record() does not fire sybgo_event_recorded when create returns false.
+	 */
+	public function test_record_does_not_fire_action_on_create_failure() {
+		$event_data = array( 'action' => 'published' );
+
+		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$this->event_repo
+			->shouldReceive( 'create' )
+			->once()
+			->andReturn( false );
+
+		Actions\expectDone( 'sybgo_event_recorded' )->never();
+
+		$this->event->test_record( 'post_published', $event_data );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test is_throttled() returns false when no prior event exists.
+	 */
+	public function test_is_throttled_false_when_no_prior_event() {
+		$this->event_repo
+			->shouldReceive( 'get_last_event_for_object' )
+			->once()
+			->with( 'post_published', 123 )
+			->andReturn( null );
+
+		$result = $this->event->test_is_throttled( 'post_published', 123, 3600 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test is_throttled() returns true when within the throttle window.
+	 */
+	public function test_is_throttled_true_within_window() {
+		$recent_timestamp = gmdate( 'Y-m-d H:i:s', time() - 1800 ); // 30 minutes ago.
+
+		$this->event_repo
+			->shouldReceive( 'get_last_event_for_object' )
+			->once()
+			->with( 'post_published', 123 )
+			->andReturn( array( 'event_timestamp' => $recent_timestamp ) );
+
+		$result = $this->event->test_is_throttled( 'post_published', 123, 3600 );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test is_throttled() returns false when outside the throttle window.
+	 */
+	public function test_is_throttled_false_outside_window() {
+		$old_timestamp = gmdate( 'Y-m-d H:i:s', time() - 7200 ); // 2 hours ago.
+
+		$this->event_repo
+			->shouldReceive( 'get_last_event_for_object' )
+			->once()
+			->with( 'post_published', 123 )
+			->andReturn( array( 'event_timestamp' => $old_timestamp ) );
+
+		$result = $this->event->test_is_throttled( 'post_published', 123, 3600 );
+
+		$this->assertFalse( $result );
+	}
+}

--- a/lib/Tests/Unit/Events/EventRegistryTest.php
+++ b/lib/Tests/Unit/Events/EventRegistryTest.php
@@ -320,6 +320,53 @@ class EventRegistryTest extends TestCase {
 	}
 
 	/**
+	 * Test get_event_category returns 'singular' by default.
+	 */
+	public function test_get_event_category_defaults_to_singular() {
+		$this->inject_event_types( array(
+			'post_published' => array( 'icon' => '📝' ),
+		) );
+
+		$this->assertEquals( 'singular', $this->registry->get_event_category( 'post_published' ) );
+	}
+
+	/**
+	 * Test get_event_category returns 'singular' when no category key is set.
+	 */
+	public function test_get_event_category_singular_for_unregistered_type() {
+		$this->inject_event_types( array() );
+
+		$this->assertEquals( 'singular', $this->registry->get_event_category( 'nonexistent_event' ) );
+	}
+
+	/**
+	 * Test get_event_category returns 'aggregated' when category key is 'aggregated'.
+	 */
+	public function test_get_event_category_returns_aggregated() {
+		$this->inject_event_types( array(
+			'page_view' => array(
+				'icon'     => '👁️',
+				'category' => 'aggregated',
+			),
+		) );
+
+		$this->assertEquals( 'aggregated', $this->registry->get_event_category( 'page_view' ) );
+	}
+
+	/**
+	 * Test get_event_category ignores unknown category values and returns 'singular'.
+	 */
+	public function test_get_event_category_ignores_unknown_category() {
+		$this->inject_event_types( array(
+			'test_event' => array(
+				'category' => 'unknown_value',
+			),
+		) );
+
+		$this->assertEquals( 'singular', $this->registry->get_event_category( 'test_event' ) );
+	}
+
+	/**
 	 * Test describe callback receives event data.
 	 */
 	public function test_describe_callback_receives_data() {

--- a/lib/class-factory.php
+++ b/lib/class-factory.php
@@ -16,11 +16,13 @@ namespace Sybgo;
 require_once __DIR__ . '/database/class-databasemanager.php';
 require_once __DIR__ . '/database/class-event-repository.php';
 require_once __DIR__ . '/database/class-report-repository.php';
+require_once __DIR__ . '/database/class-aggregated-event-repository.php';
 require_once __DIR__ . '/events/class-event-registry.php';
 
 use Sybgo\Database\DatabaseManager;
 use Sybgo\Database\Event_Repository;
 use Sybgo\Database\Report_Repository;
+use Sybgo\Database\Aggregated_Event_Repository;
 use Sybgo\Events\Event_Registry;
 
 /**
@@ -86,6 +88,13 @@ class Factory {
 	 * @var object|null
 	 */
 	private static ?object $email_manager_instance = null;
+
+	/**
+	 * Aggregated event repository instance.
+	 *
+	 * @var Aggregated_Event_Repository|null
+	 */
+	private static ?Aggregated_Event_Repository $aggregated_event_repo_instance = null;
 
 	/**
 	 * Event registry instance.
@@ -167,6 +176,20 @@ class Factory {
 			self::$report_repo_instance = new Report_Repository( $tables['reports'] );
 		}
 		return self::$report_repo_instance;
+	}
+
+	/**
+	 * Create aggregated event repository instance.
+	 *
+	 * @return Aggregated_Event_Repository The aggregated event repository instance.
+	 */
+	public function create_aggregated_event_repository(): Aggregated_Event_Repository {
+		if ( null === self::$aggregated_event_repo_instance ) {
+			$db_manager                           = $this->create_database_manager();
+			$tables                               = $db_manager->get_table_names();
+			self::$aggregated_event_repo_instance = new Aggregated_Event_Repository( $tables['aggregated_events'] );
+		}
+		return self::$aggregated_event_repo_instance;
 	}
 
 	/**

--- a/lib/database/class-aggregated-event-repository.php
+++ b/lib/database/class-aggregated-event-repository.php
@@ -2,7 +2,7 @@
 /**
  * Aggregated Event Repository class file.
  *
- * This file defines the Aggregated Event Repository for upsert operations on daily event counts.
+ * This file defines the Aggregated Event Repository for upsert operations on daily event values.
  *
  * @package Sybgo\Database
  * @since   1.0.0
@@ -16,7 +16,8 @@ namespace Sybgo\Database;
  * Aggregated Event Repository class.
  *
  * Handles database operations for the aggregated_events table.
- * Uses INSERT ... ON DUPLICATE KEY UPDATE to increment daily counts.
+ * Uses INSERT ... ON DUPLICATE KEY UPDATE to accumulate daily values per event type
+ * and dimension set. The dimensions_hash column is computed by MySQL automatically.
  *
  * @package Sybgo\Database
  * @since   1.0.0
@@ -39,33 +40,61 @@ class Aggregated_Event_Repository {
 	}
 
 	/**
-	 * Insert or increment the daily count for an event type.
+	 * Insert or accumulate a daily value for an event type and dimension set.
 	 *
-	 * Creates a new row for the given event_type + date combination,
-	 * or increments the count if that combination already exists.
+	 * Creates a new row for the given (event_type, dimensions, date) combination,
+	 * or adds $value to the existing row if that combination already exists.
+	 * Meta is overwritten (last-write-wins) on conflict — use it for context snapshots.
 	 *
-	 * @param string               $event_type Event type identifier.
-	 * @param string               $date       Date string in Y-m-d format.
-	 * @param array<string, mixed> $meta       Optional metadata to store alongside the count.
+	 * @param string               $event_type  Event type identifier.
+	 * @param string               $date        Date string in Y-m-d format.
+	 * @param float                $value       Amount to accumulate (default 1.0 for simple counts).
+	 * @param array<string, mixed> $dimensions  Breakdown axes as key→value pairs (e.g. ['role' => 'editor']).
+	 *                                          Empty array produces a global row with dimensions = '{}'.
+	 * @param array<string, mixed> $meta        Optional context snapshot stored alongside the value.
 	 * @return bool True on success, false on failure.
 	 */
-	public function upsert_count( string $event_type, string $date, array $meta = array() ): bool {
+	public function upsert(
+		string $event_type,
+		string $date,
+		float $value = 1.0,
+		array $dimensions = array(),
+		array $meta = array()
+	): bool {
 		global $wpdb;
 
-		$meta_json = wp_json_encode( $meta );
+		$dimensions_json = $this->encode_dimensions( $dimensions );
+		$meta_json       = wp_json_encode( $meta );
 
 		$result = $wpdb->query(
 			$wpdb->prepare(
-				"INSERT INTO {$this->table} (event_type, count, date, meta)
-				VALUES (%s, 1, %s, %s)
-				ON DUPLICATE KEY UPDATE count = count + 1, meta = %s",
+				"INSERT INTO {$this->table} (event_type, dimensions, value, date, meta)
+				VALUES (%s, %s, %f, %s, %s)
+				ON DUPLICATE KEY UPDATE value = value + VALUES(value), meta = VALUES(meta)",
 				$event_type,
+				$dimensions_json,
+				$value,
 				$date,
-				$meta_json,
 				$meta_json
 			)
 		);
 
 		return false !== $result;
+	}
+
+	/**
+	 * Encode dimensions array to canonical JSON.
+	 *
+	 * Keys are sorted alphabetically so the same set of dimensions always produces
+	 * the same JSON string (and therefore the same SHA2 hash in dimensions_hash).
+	 * An empty dimensions array encodes to '{}' — not null — so the UNIQUE KEY
+	 * produces a stable hash for global (non-dimensioned) rows.
+	 *
+	 * @param array<string, mixed> $dimensions Dimension key→value pairs.
+	 * @return string Canonical JSON string.
+	 */
+	private function encode_dimensions( array $dimensions ): string {
+		ksort( $dimensions );
+		return (string) wp_json_encode( $dimensions, JSON_FORCE_OBJECT );
 	}
 }

--- a/lib/database/class-aggregated-event-repository.php
+++ b/lib/database/class-aggregated-event-repository.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Aggregated Event Repository class file.
+ *
+ * This file defines the Aggregated Event Repository for upsert operations on daily event counts.
+ *
+ * @package Sybgo\Database
+ * @since   1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Database;
+
+/**
+ * Aggregated Event Repository class.
+ *
+ * Handles database operations for the aggregated_events table.
+ * Uses INSERT ... ON DUPLICATE KEY UPDATE to increment daily counts.
+ *
+ * @package Sybgo\Database
+ * @since   1.0.0
+ */
+class Aggregated_Event_Repository {
+	/**
+	 * Table name for aggregated events.
+	 *
+	 * @var string
+	 */
+	private string $table;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $table The aggregated events table name.
+	 */
+	public function __construct( string $table ) {
+		$this->table = $table;
+	}
+
+	/**
+	 * Insert or increment the daily count for an event type.
+	 *
+	 * Creates a new row for the given event_type + date combination,
+	 * or increments the count if that combination already exists.
+	 *
+	 * @param string               $event_type Event type identifier.
+	 * @param string               $date       Date string in Y-m-d format.
+	 * @param array<string, mixed> $meta       Optional metadata to store alongside the count.
+	 * @return bool True on success, false on failure.
+	 */
+	public function upsert_count( string $event_type, string $date, array $meta = array() ): bool {
+		global $wpdb;
+
+		$meta_json = wp_json_encode( $meta );
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$this->table} (event_type, count, date, meta)
+				VALUES (%s, 1, %s, %s)
+				ON DUPLICATE KEY UPDATE count = count + 1, meta = %s",
+				$event_type,
+				$date,
+				$meta_json,
+				$meta_json
+			)
+		);
+
+		return false !== $result;
+	}
+}

--- a/lib/database/class-databasemanager.php
+++ b/lib/database/class-databasemanager.php
@@ -134,15 +134,21 @@ class DatabaseManager {
 			INDEX idx_status (status)
 		) $charset_collate;";
 
-		// Aggregated events table - stores daily counts per event type.
+		// Aggregated events table - stores daily accumulated values per event type and dimension set.
+		// dimensions_hash is a MySQL generated column (SHA2 of the dimensions JSON blob) used in
+		// the UNIQUE KEY because LONGTEXT columns cannot be indexed directly.
+		// Empty dimensions are encoded as '{}' (not NULL) to produce a stable hash for global rows.
 		$aggregated_events_sql = "CREATE TABLE {$this->aggregated_events_table} (
 			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
 			event_type VARCHAR(100) NOT NULL,
-			count INT UNSIGNED DEFAULT 1,
+			dimensions LONGTEXT DEFAULT NULL,
+			dimensions_hash VARCHAR(64) GENERATED ALWAYS AS (SHA2(dimensions, 256)) STORED,
+			value DECIMAL(20,4) NOT NULL DEFAULT 0,
 			date DATE NOT NULL,
 			meta LONGTEXT DEFAULT NULL,
-			UNIQUE KEY uq_event_date (event_type, date),
-			INDEX idx_date (date)
+			UNIQUE KEY uq_event_dim_date (event_type, dimensions_hash, date),
+			INDEX idx_date (date),
+			INDEX idx_event_type (event_type)
 		) $charset_collate;";
 
 		// Execute table creation.

--- a/lib/database/class-databasemanager.php
+++ b/lib/database/class-databasemanager.php
@@ -16,7 +16,7 @@ namespace Sybgo\Database;
  * DatabaseManager class.
  *
  * This class provides methods for managing database interactions for the Sybgo plugin.
- * Creates and manages three tables: events, reports, and email_log.
+ * Creates and manages four tables: events, reports, email_log, and aggregated_events.
  *
  * @package Sybgo\Database
  * @since   1.0.0
@@ -47,6 +47,14 @@ class DatabaseManager {
 	private string $email_log_table = '';
 
 	/**
+	 * Table name for storing aggregated event counts.
+	 *
+	 * @var string $aggregated_events_table The name of the aggregated events database table.
+	 * @since 1.0.0
+	 */
+	private string $aggregated_events_table = '';
+
+	/**
 	 * Constructor for the DatabaseManager class.
 	 *
 	 * This method initializes the database manager and sets up all required tables.
@@ -58,9 +66,10 @@ class DatabaseManager {
 		global $wpdb;
 
 		// Set table names.
-		$this->events_table    = $wpdb->prefix . 'sybgo_events';
-		$this->reports_table   = $wpdb->prefix . 'sybgo_reports';
-		$this->email_log_table = $wpdb->prefix . 'sybgo_email_log';
+		$this->events_table            = $wpdb->prefix . 'sybgo_events';
+		$this->reports_table           = $wpdb->prefix . 'sybgo_reports';
+		$this->email_log_table         = $wpdb->prefix . 'sybgo_email_log';
+		$this->aggregated_events_table = $wpdb->prefix . 'sybgo_aggregated_events';
 
 		// Create tables.
 		$this->create_tables();
@@ -125,10 +134,22 @@ class DatabaseManager {
 			INDEX idx_status (status)
 		) $charset_collate;";
 
+		// Aggregated events table - stores daily counts per event type.
+		$aggregated_events_sql = "CREATE TABLE {$this->aggregated_events_table} (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			event_type VARCHAR(100) NOT NULL,
+			count INT UNSIGNED DEFAULT 1,
+			date DATE NOT NULL,
+			meta LONGTEXT DEFAULT NULL,
+			UNIQUE KEY uq_event_date (event_type, date),
+			INDEX idx_date (date)
+		) $charset_collate;";
+
 		// Execute table creation.
 		dbDelta( $events_sql );
 		dbDelta( $reports_sql );
 		dbDelta( $email_log_sql );
+		dbDelta( $aggregated_events_sql );
 	}
 
 	/**
@@ -160,9 +181,10 @@ class DatabaseManager {
 	 */
 	public function get_table_names(): array {
 		return array(
-			'events'    => $this->events_table,
-			'reports'   => $this->reports_table,
-			'email_log' => $this->email_log_table,
+			'events'            => $this->events_table,
+			'reports'           => $this->reports_table,
+			'email_log'         => $this->email_log_table,
+			'aggregated_events' => $this->aggregated_events_table,
 		);
 	}
 

--- a/lib/docs/event-tracking.md
+++ b/lib/docs/event-tracking.md
@@ -40,13 +40,13 @@ Trackers extend one of two abstract base classes in `lib/events/abstracts/`, dep
 
 - **`Abstract_Singular_Event`** — for events logged individually. Provides `record()` (persists the event, applies `sybgo_event_data` and `sybgo_should_track_event` filters, fires `sybgo_event_recorded`) and `is_throttled()` (checks whether a recent event for the same object is within a given window). The constructor automatically wires the `sybgo_event_types` filter. All 4 built-in trackers extend this class.
 
-- **`Abstract_Aggregated_Event`** — for events counted daily rather than logged individually. Provides `increment()`, which upserts a row in `wp_sybgo_aggregated_events` for today's date. No filter registration is done automatically; subclasses hook into WordPress actions directly.
+- **`Abstract_Aggregated_Event`** — for events accumulated daily rather than logged individually. Provides `increment(string $event_type, float $value = 1.0, array $dimensions = [], array $meta = [])`, which upserts a row in `wp_sybgo_aggregated_events` for today's date. Pass `$value = 1.0` for simple counts, or a decimal (e.g. `249.95`) to accumulate sums such as revenue. Pass `$dimensions` to break the metric down per object, role, product, etc. No filter registration is done automatically; subclasses hook into WordPress actions directly.
 
 ### Event Categories
 
 Every event type belongs to a category: `'singular'` (default) or `'aggregated'`. The category is declared via the `category` key when registering the event type on the `sybgo_event_types` filter. `Event_Registry::get_event_category( $event_type )` returns the category string.
 
-Singular events are written to `wp_sybgo_events` (one row per occurrence). Aggregated events are written to `wp_sybgo_aggregated_events` (one row per event type per day, with an incrementing count).
+Singular events are written to `wp_sybgo_events` (one row per occurrence). Aggregated events are written to `wp_sybgo_aggregated_events` (one row per `(event_type, dimensions, date)` combination, with an accumulating `value`).
 
 ### Event Data Structure
 
@@ -155,7 +155,7 @@ Shows all reports (active, frozen, emailed) with period dates, event counts, sta
 
 ### Database Inspection
 
-Singular events are stored in `wp_sybgo_events` (one row per occurrence). Aggregated events are stored in `wp_sybgo_aggregated_events`, with a unique constraint on `(event_type, date)` so each event type has at most one row per day.
+Singular events are stored in `wp_sybgo_events` (one row per occurrence). Aggregated events are stored in `wp_sybgo_aggregated_events`, with a unique constraint on `(event_type, dimensions_hash, date)` so each `(event_type, dimension set, date)` combination has at most one row.
 
 The `wp_sybgo_aggregated_events` schema (defined in `DatabaseManager::create_tables()`):
 
@@ -163,9 +163,21 @@ The `wp_sybgo_aggregated_events` schema (defined in `DatabaseManager::create_tab
 |---|---|---|
 | `id` | BIGINT UNSIGNED | Auto-increment PK |
 | `event_type` | VARCHAR(100) | Event type identifier |
-| `count` | INT UNSIGNED | Daily occurrence count |
-| `date` | DATE | Date of the counts (Y-m-d) |
-| `meta` | LONGTEXT | Optional JSON metadata |
+| `dimensions` | LONGTEXT | JSON blob of breakdown axes, e.g. `{"role":"editor","product_id":42}`. Empty = `'{}'` (global row). |
+| `dimensions_hash` | VARCHAR(64) | SHA2-256 of `dimensions`, computed by MySQL automatically. Used in the UNIQUE KEY. |
+| `value` | DECIMAL(20,4) | Accumulated value for the day (count or sum). Default 0. |
+| `date` | DATE | Date of the aggregation (Y-m-d) |
+| `meta` | LONGTEXT | Optional JSON context snapshot (overwritten on conflict, not accumulated) |
+
+**Use-case examples:**
+
+| Use case | `event_type` | `dimensions` | `value` delta |
+|---|---|---|---|
+| Page visits per page | `page_view` | `{"post_id": 42}` | 1.0 |
+| PHP errors per error type | `php_error` | `{"error_code": "E_WARNING"}` | 1.0 |
+| WooCommerce units per product | `woo_sale_units` | `{"product_id": 99}` | 1.0 |
+| WooCommerce revenue per product | `woo_sale_revenue` | `{"product_id": 99}` | 249.95 |
+| User registrations per role | `user_registered` | `{"role": "editor"}` | 1.0 |
 
 ```sql
 -- View recent singular events
@@ -180,10 +192,28 @@ FROM wp_sybgo_events
 WHERE report_id IS NULL  -- Current week only
 GROUP BY event_type;
 
--- View aggregated daily counts
-SELECT event_type, date, count
+-- Top 10 pages by visits today
+SELECT JSON_UNQUOTE(JSON_EXTRACT(dimensions, '$.post_id')) AS post_id,
+       SUM(value) AS visits
 FROM wp_sybgo_aggregated_events
-ORDER BY date DESC, count DESC;
+WHERE event_type = 'page_view' AND date = CURDATE()
+GROUP BY post_id ORDER BY visits DESC LIMIT 10;
+
+-- Revenue per product this week
+SELECT JSON_UNQUOTE(JSON_EXTRACT(dimensions, '$.product_id')) AS product_id,
+       SUM(value) AS revenue
+FROM wp_sybgo_aggregated_events
+WHERE event_type = 'woo_sale_revenue'
+  AND date BETWEEN DATE_SUB(CURDATE(), INTERVAL 7 DAY) AND CURDATE()
+GROUP BY product_id ORDER BY revenue DESC;
+
+-- User registrations per role last 30 days
+SELECT JSON_UNQUOTE(JSON_EXTRACT(dimensions, '$.role')) AS role,
+       date, SUM(value) AS registrations
+FROM wp_sybgo_aggregated_events
+WHERE event_type = 'user_registered'
+  AND date >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
+GROUP BY role, date ORDER BY date, role;
 ```
 
 ## Troubleshooting

--- a/lib/docs/event-tracking.md
+++ b/lib/docs/event-tracking.md
@@ -34,6 +34,20 @@ Sybgo tracks 16 different event types across 4 categories:
 
 When you perform an action in WordPress (publish a post, approve a comment, etc.), Sybgo's tracker classes listen for the corresponding WordPress hook and create an event record. Each tracker registers its event types via the `sybgo_event_types` filter and hooks into WordPress actions to capture events.
 
+### Tracker Class Hierarchy
+
+Trackers extend one of two abstract base classes in `lib/events/abstracts/`, depending on the storage strategy:
+
+- **`Abstract_Singular_Event`** — for events logged individually. Provides `record()` (persists the event, applies `sybgo_event_data` and `sybgo_should_track_event` filters, fires `sybgo_event_recorded`) and `is_throttled()` (checks whether a recent event for the same object is within a given window). The constructor automatically wires the `sybgo_event_types` filter. All 4 built-in trackers extend this class.
+
+- **`Abstract_Aggregated_Event`** — for events counted daily rather than logged individually. Provides `increment()`, which upserts a row in `wp_sybgo_aggregated_events` for today's date. No filter registration is done automatically; subclasses hook into WordPress actions directly.
+
+### Event Categories
+
+Every event type belongs to a category: `'singular'` (default) or `'aggregated'`. The category is declared via the `category` key when registering the event type on the `sybgo_event_types` filter. `Event_Registry::get_event_category( $event_type )` returns the category string.
+
+Singular events are written to `wp_sybgo_events` (one row per occurrence). Aggregated events are written to `wp_sybgo_aggregated_events` (one row per event type per day, with an incrementing count).
+
 ### Event Data Structure
 
 Each event stores the following information:
@@ -141,8 +155,20 @@ Shows all reports (active, frozen, emailed) with period dates, event counts, sta
 
 ### Database Inspection
 
+Singular events are stored in `wp_sybgo_events` (one row per occurrence). Aggregated events are stored in `wp_sybgo_aggregated_events`, with a unique constraint on `(event_type, date)` so each event type has at most one row per day.
+
+The `wp_sybgo_aggregated_events` schema (defined in `DatabaseManager::create_tables()`):
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT UNSIGNED | Auto-increment PK |
+| `event_type` | VARCHAR(100) | Event type identifier |
+| `count` | INT UNSIGNED | Daily occurrence count |
+| `date` | DATE | Date of the counts (Y-m-d) |
+| `meta` | LONGTEXT | Optional JSON metadata |
+
 ```sql
--- View recent events
+-- View recent singular events
 SELECT event_type, JSON_EXTRACT(event_data, '$.object.title') as title, event_timestamp
 FROM wp_sybgo_events
 ORDER BY event_timestamp DESC
@@ -154,15 +180,10 @@ FROM wp_sybgo_events
 WHERE report_id IS NULL  -- Current week only
 GROUP BY event_type;
 
--- View edit magnitude for recent edits
-SELECT
-    JSON_EXTRACT(event_data, '$.object.title') as title,
-    JSON_EXTRACT(event_data, '$.metadata.edit_magnitude') as edit_pct,
-    event_timestamp
-FROM wp_sybgo_events
-WHERE event_type = 'post_edited'
-ORDER BY event_timestamp DESC
-LIMIT 10;
+-- View aggregated daily counts
+SELECT event_type, date, count
+FROM wp_sybgo_aggregated_events
+ORDER BY date DESC, count DESC;
 ```
 
 ## Troubleshooting

--- a/lib/docs/extension-api.md
+++ b/lib/docs/extension-api.md
@@ -105,6 +105,7 @@ add_filter( 'sybgo_event_types', function( array $types ): array {
 **Registration keys:**
 - `icon` - Emoji displayed in dashboard and emails
 - `stat_label` - Human-readable label for statistics
+- `category` - Storage strategy: `'singular'` (default, one row per event in `wp_sybgo_events`) or `'aggregated'` (daily count in `wp_sybgo_aggregated_events`). Readable via `Event_Registry::get_event_category()`.
 - `short_title` - Callable returning a short display title
 - `detailed_title` - Callable returning a detailed display title
 - `ai_description` - Callable providing context for AI summaries

--- a/lib/events/abstracts/class-abstract-aggregated-event.php
+++ b/lib/events/abstracts/class-abstract-aggregated-event.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Abstract Aggregated Event class file.
+ *
+ * Base class for events that are counted daily in the aggregated_events table.
+ *
+ * @package Sybgo\Events\Abstracts
+ * @since   1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Events\Abstracts;
+
+use Sybgo\Database\Aggregated_Event_Repository;
+
+/**
+ * Abstract Aggregated Event class.
+ *
+ * Provides the increment() method for trackers that count daily occurrences
+ * rather than logging each event individually.
+ *
+ * @package Sybgo\Events\Abstracts
+ * @since   1.0.0
+ */
+abstract class Abstract_Aggregated_Event {
+	/**
+	 * Aggregated event repository instance.
+	 *
+	 * @var Aggregated_Event_Repository
+	 */
+	protected Aggregated_Event_Repository $aggregated_repo;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Aggregated_Event_Repository $aggregated_repo Aggregated event repository instance.
+	 */
+	public function __construct( Aggregated_Event_Repository $aggregated_repo ) {
+		$this->aggregated_repo = $aggregated_repo;
+	}
+
+	/**
+	 * Increment the daily count for an event type.
+	 *
+	 * @param string               $event_type Event type identifier.
+	 * @param array<string, mixed> $meta       Optional metadata to store alongside the count.
+	 * @return void
+	 */
+	protected function increment( string $event_type, array $meta = array() ): void {
+		$date = gmdate( 'Y-m-d' );
+		$this->aggregated_repo->upsert_count( $event_type, $date, $meta );
+	}
+
+	/**
+	 * Register WordPress hooks for this tracker.
+	 *
+	 * @return void
+	 */
+	abstract public function register_hooks(): void;
+}

--- a/lib/events/abstracts/class-abstract-aggregated-event.php
+++ b/lib/events/abstracts/class-abstract-aggregated-event.php
@@ -17,8 +17,9 @@ use Sybgo\Database\Aggregated_Event_Repository;
 /**
  * Abstract Aggregated Event class.
  *
- * Provides the increment() method for trackers that count daily occurrences
- * rather than logging each event individually.
+ * Provides the increment() method for trackers that accumulate daily values
+ * rather than logging each event individually. Supports multi-dimensional
+ * breakdowns (e.g. per role, per product) via the $dimensions parameter.
  *
  * @package Sybgo\Events\Abstracts
  * @since   1.0.0
@@ -41,15 +42,26 @@ abstract class Abstract_Aggregated_Event {
 	}
 
 	/**
-	 * Increment the daily count for an event type.
+	 * Accumulate a daily value for an event type and optional dimension set.
 	 *
-	 * @param string               $event_type Event type identifier.
-	 * @param array<string, mixed> $meta       Optional metadata to store alongside the count.
+	 * Pass $value = 1.0 (the default) for simple event counts.
+	 * Pass a decimal amount (e.g. 249.95) to accumulate sums such as revenue.
+	 * Pass $dimensions to break the metric down by object, role, product, etc.
+	 *
+	 * @param string               $event_type  Event type identifier.
+	 * @param float                $value       Amount to accumulate. Default 1.0.
+	 * @param array<string, mixed> $dimensions  Breakdown axes as key→value pairs (e.g. ['role' => 'editor']).
+	 * @param array<string, mixed> $meta        Optional context snapshot stored alongside the value.
 	 * @return void
 	 */
-	protected function increment( string $event_type, array $meta = array() ): void {
+	protected function increment(
+		string $event_type,
+		float $value = 1.0,
+		array $dimensions = array(),
+		array $meta = array()
+	): void {
 		$date = gmdate( 'Y-m-d' );
-		$this->aggregated_repo->upsert_count( $event_type, $date, $meta );
+		$this->aggregated_repo->upsert( $event_type, $date, $value, $dimensions, $meta );
 	}
 
 	/**

--- a/lib/events/abstracts/class-abstract-singular-event.php
+++ b/lib/events/abstracts/class-abstract-singular-event.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Abstract Singular Event class file.
+ *
+ * Base class for events that are logged individually in the events table.
+ *
+ * @package Sybgo\Events\Abstracts
+ * @since   1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Events\Abstracts;
+
+use Sybgo\Database\Event_Repository;
+
+/**
+ * Abstract Singular Event class.
+ *
+ * Provides shared boilerplate for trackers that log individual events:
+ * record(), is_throttled(), and automatic filter registration.
+ *
+ * @package Sybgo\Events\Abstracts
+ * @since   1.0.0
+ */
+abstract class Abstract_Singular_Event {
+	/**
+	 * Event repository instance.
+	 *
+	 * @var Event_Repository
+	 */
+	protected Event_Repository $event_repo;
+
+	/**
+	 * Constructor.
+	 *
+	 * Stores the repository and registers event types via filter.
+	 *
+	 * @param Event_Repository $event_repo Event repository instance.
+	 */
+	public function __construct( Event_Repository $event_repo ) {
+		$this->event_repo = $event_repo;
+		add_filter( 'sybgo_event_types', array( $this, 'register_event_types' ) );
+	}
+
+	/**
+	 * Record a singular event.
+	 *
+	 * Applies the sybgo_event_data and sybgo_should_track_event filters,
+	 * persists the event, then fires sybgo_event_recorded.
+	 *
+	 * @param string               $event_type Event type identifier.
+	 * @param array<string, mixed> $event_data Event payload.
+	 * @param string               $source     Source plugin identifier.
+	 * @return void
+	 */
+	protected function record( string $event_type, array $event_data, string $source = 'core' ): void {
+		$event_data = apply_filters( 'sybgo_event_data', $event_data, $event_type );
+
+		$should_track = apply_filters( 'sybgo_should_track_event', true, $event_type, $event_data );
+		if ( ! $should_track ) {
+			return;
+		}
+
+		$event_id = $this->event_repo->create(
+			array(
+				'event_type'    => $event_type,
+				'event_data'    => $event_data,
+				'source_plugin' => $source,
+			)
+		);
+
+		if ( $event_id ) {
+			do_action( 'sybgo_event_recorded', $event_id, $event_type, $event_data );
+		}
+	}
+
+	/**
+	 * Check whether an event for a given object is within a throttle period.
+	 *
+	 * @param string $event_type Event type identifier.
+	 * @param int    $object_id  Object ID (post ID, user ID, etc.).
+	 * @param int    $seconds    Throttle window in seconds.
+	 * @return bool True if within the throttle window (skip the event), false otherwise.
+	 */
+	protected function is_throttled( string $event_type, int $object_id, int $seconds ): bool {
+		$last_event = $this->event_repo->get_last_event_for_object( $event_type, $object_id );
+
+		if ( ! $last_event ) {
+			return false;
+		}
+
+		$time_since = time() - strtotime( $last_event['event_timestamp'] );
+
+		return $time_since < $seconds;
+	}
+
+	/**
+	 * Register WordPress hooks for this tracker.
+	 *
+	 * @return void
+	 */
+	abstract public function register_hooks(): void;
+
+	/**
+	 * Register event types via the sybgo_event_types filter.
+	 *
+	 * @param array<string, array<string, mixed>> $types Existing event types.
+	 * @return array<string, array<string, mixed>> Modified event types.
+	 */
+	abstract public function register_event_types( array $types ): array;
+}

--- a/lib/events/class-event-registry.php
+++ b/lib/events/class-event-registry.php
@@ -179,6 +179,25 @@ class Event_Registry {
 	}
 
 	/**
+	 * Get the category of an event type.
+	 *
+	 * Returns 'singular' for individually-logged events (default)
+	 * and 'aggregated' for daily-counted events.
+	 *
+	 * @param string $event_type Event type identifier.
+	 * @return string 'singular' or 'aggregated'.
+	 */
+	public function get_event_category( string $event_type ): string {
+		$type = $this->get_event_type( $event_type );
+
+		if ( isset( $type['category'] ) && 'aggregated' === $type['category'] ) {
+			return 'aggregated';
+		}
+
+		return 'singular';
+	}
+
+	/**
 	 * Get AI context for a report.
 	 *
 	 * Generates full AI context including event type descriptions.

--- a/lib/events/trackers/class-comment-tracker.php
+++ b/lib/events/trackers/class-comment-tracker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Sybgo\Events\Trackers;
 
 use Sybgo\Database\Event_Repository;
+use Sybgo\Events\Abstracts\Abstract_Singular_Event;
 
 /**
  * Comment Tracker class.
@@ -22,26 +23,7 @@ use Sybgo\Database\Event_Repository;
  * @package Sybgo\Events\Trackers
  * @since   1.0.0
  */
-class Comment_Tracker {
-	/**
-	 * Event repository instance.
-	 *
-	 * @var Event_Repository
-	 */
-	private Event_Repository $event_repo;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param Event_Repository $event_repo Event repository instance.
-	 */
-	public function __construct( Event_Repository $event_repo ) {
-		$this->event_repo = $event_repo;
-
-		// Register event types via filter.
-		add_filter( 'sybgo_event_types', array( $this, 'register_event_types' ) );
-	}
-
+class Comment_Tracker extends Abstract_Singular_Event {
 	/**
 	 * Register WordPress hooks.
 	 *
@@ -213,13 +195,7 @@ class Comment_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'comment_posted',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'comment_posted', $event_data );
 	}
 
 	/**
@@ -272,12 +248,6 @@ class Comment_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => $event_type,
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( $event_type, $event_data );
 	}
 }

--- a/lib/events/trackers/class-post-tracker.php
+++ b/lib/events/trackers/class-post-tracker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Sybgo\Events\Trackers;
 
 use Sybgo\Database\Event_Repository;
+use Sybgo\Events\Abstracts\Abstract_Singular_Event;
 
 /**
  * Post Tracker class.
@@ -22,32 +23,13 @@ use Sybgo\Database\Event_Repository;
  * @package Sybgo\Events\Trackers
  * @since   1.0.0
  */
-class Post_Tracker {
-	/**
-	 * Event repository instance.
-	 *
-	 * @var Event_Repository
-	 */
-	private Event_Repository $event_repo;
-
+class Post_Tracker extends Abstract_Singular_Event {
 	/**
 	 * Throttle period in seconds (1 hour).
 	 *
 	 * @var int
 	 */
 	private int $throttle_period = 3600;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param Event_Repository $event_repo Event repository instance.
-	 */
-	public function __construct( Event_Repository $event_repo ) {
-		$this->event_repo = $event_repo;
-
-		// Register event types via filter.
-		add_filter( 'sybgo_event_types', array( $this, 'register_event_types' ) );
-	}
 
 	/**
 	 * Register WordPress hooks.
@@ -189,12 +171,8 @@ class Post_Tracker {
 		}
 
 		// Check throttling.
-		$last_event = $this->event_repo->get_last_event_for_object( 'post_published', $post->ID );
-		if ( $last_event ) {
-			$time_since = time() - strtotime( $last_event['event_timestamp'] );
-			if ( $time_since < $this->throttle_period ) {
-				return; // Skip, within throttle period.
-			}
+		if ( $this->is_throttled( 'post_published', $post->ID, $this->throttle_period ) ) {
+			return; // Skip, within throttle period.
 		}
 
 		// Build event data.
@@ -218,13 +196,7 @@ class Post_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'post_published',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'post_published', $event_data );
 	}
 
 	/**
@@ -252,12 +224,8 @@ class Post_Tracker {
 		}
 
 		// Check throttling (1 event per post per hour).
-		$last_event = $this->event_repo->get_last_event_for_object( 'post_edited', $post_id );
-		if ( $last_event ) {
-			$time_since = time() - strtotime( $last_event['event_timestamp'] );
-			if ( $time_since < $this->throttle_period ) {
-				return; // Skip, within throttle period.
-			}
+		if ( $this->is_throttled( 'post_edited', $post_id, $this->throttle_period ) ) {
+			return; // Skip, within throttle period.
 		}
 
 		// Calculate edit magnitude.
@@ -292,13 +260,7 @@ class Post_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'post_edited',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'post_edited', $event_data );
 	}
 
 	/**
@@ -328,13 +290,7 @@ class Post_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'post_deleted',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'post_deleted', $event_data );
 	}
 
 	/**

--- a/lib/events/trackers/class-update-tracker.php
+++ b/lib/events/trackers/class-update-tracker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Sybgo\Events\Trackers;
 
 use Sybgo\Database\Event_Repository;
+use Sybgo\Events\Abstracts\Abstract_Singular_Event;
 
 /**
  * Update Tracker class.
@@ -22,26 +23,7 @@ use Sybgo\Database\Event_Repository;
  * @package Sybgo\Events\Trackers
  * @since   1.0.0
  */
-class Update_Tracker {
-	/**
-	 * Event repository instance.
-	 *
-	 * @var Event_Repository
-	 */
-	private Event_Repository $event_repo;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param Event_Repository $event_repo Event repository instance.
-	 */
-	public function __construct( Event_Repository $event_repo ) {
-		$this->event_repo = $event_repo;
-
-		// Register event types via filter.
-		add_filter( 'sybgo_event_types', array( $this, 'register_event_types' ) );
-	}
-
+class Update_Tracker extends Abstract_Singular_Event {
 	/**
 	 * Register WordPress hooks.
 	 *
@@ -319,13 +301,7 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'core_updated',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'core_updated', $event_data );
 
 		// Store current version for next update.
 		set_transient( 'sybgo_wp_version_before_update', $new_version, DAY_IN_SECONDS );
@@ -404,13 +380,7 @@ class Update_Tracker {
 				),
 			);
 
-			// Create event.
-			$this->event_repo->create(
-				array(
-					'event_type' => 'plugin_updated',
-					'event_data' => $event_data,
-				)
-			);
+			$this->record( 'plugin_updated', $event_data );
 
 			// Store current version.
 			set_transient( 'sybgo_plugin_version_' . $slug, $plugin_data['Version'], MONTH_IN_SECONDS );
@@ -452,13 +422,7 @@ class Update_Tracker {
 				),
 			);
 
-			// Create event.
-			$this->event_repo->create(
-				array(
-					'event_type' => 'theme_updated',
-					'event_data' => $event_data,
-				)
-			);
+			$this->record( 'theme_updated', $event_data );
 
 			// Store current version.
 			set_transient( 'sybgo_theme_version_' . $theme_slug, $theme->get( 'Version' ), MONTH_IN_SECONDS );
@@ -536,13 +500,7 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'plugin_installed',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'plugin_installed', $event_data );
 	}
 
 	/**
@@ -582,13 +540,7 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'plugin_activated',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'plugin_activated', $event_data );
 	}
 
 	/**
@@ -627,13 +579,7 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'plugin_deactivated',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'plugin_deactivated', $event_data );
 	}
 
 	/**
@@ -673,13 +619,7 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'theme_installed',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'theme_installed', $event_data );
 	}
 
 	/**
@@ -709,12 +649,6 @@ class Update_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'theme_switched',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'theme_switched', $event_data );
 	}
 }

--- a/lib/events/trackers/class-user-tracker.php
+++ b/lib/events/trackers/class-user-tracker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Sybgo\Events\Trackers;
 
 use Sybgo\Database\Event_Repository;
+use Sybgo\Events\Abstracts\Abstract_Singular_Event;
 
 /**
  * User Tracker class.
@@ -22,26 +23,7 @@ use Sybgo\Database\Event_Repository;
  * @package Sybgo\Events\Trackers
  * @since   1.0.0
  */
-class User_Tracker {
-	/**
-	 * Event repository instance.
-	 *
-	 * @var Event_Repository
-	 */
-	private Event_Repository $event_repo;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param Event_Repository $event_repo Event repository instance.
-	 */
-	public function __construct( Event_Repository $event_repo ) {
-		$this->event_repo = $event_repo;
-
-		// Register event types via filter.
-		add_filter( 'sybgo_event_types', array( $this, 'register_event_types' ) );
-	}
-
+class User_Tracker extends Abstract_Singular_Event {
 	/**
 	 * Register WordPress hooks.
 	 *
@@ -185,13 +167,7 @@ class User_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'user_registered',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'user_registered', $event_data );
 	}
 
 	/**
@@ -229,13 +205,7 @@ class User_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'user_role_changed',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'user_role_changed', $event_data );
 	}
 
 	/**
@@ -271,12 +241,6 @@ class User_Tracker {
 			),
 		);
 
-		// Create event.
-		$this->event_repo->create(
-			array(
-				'event_type' => 'user_deleted',
-				'event_data' => $event_data,
-			)
-		);
+		$this->record( 'user_deleted', $event_data );
 	}
 }


### PR DESCRIPTION
# Description

Fixes:
- #7 (EPIC: Abstract Event Classes)
- #24 (Create Abstract_Singular_Event base class)
- #25 (Create Abstract_Aggregated_Event and wp_sybgo_aggregated_events table)
- #26 (Refactor all 4 trackers to extend Abstract_Singular_Event)
- #27 (Add event category support to Event_Registry)

Introduces two abstract base classes (`Abstract_Singular_Event` and `Abstract_Aggregated_Event`) that eliminate boilerplate duplicated across the 4 event trackers. Adds `wp_sybgo_aggregated_events` — a flexible table supporting per-dimension daily accumulation (counts, sums, revenue) — and exposes event category via `Event_Registry::get_event_category()`.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

1. **Abstract_Singular_Event::record()** — unit tested with a concrete test double; verified `sybgo_event_types` filter auto-registers, `record()` calls `event_repo->create()` with the correct payload, fires `sybgo_event_recorded` action, and is skipped when `sybgo_should_track_event` filter returns false.

2. **Abstract_Singular_Event::is_throttled()** — unit tested: returns `false` when no prior event exists, `true` when the last event is within the throttle window, `false` when outside the window.

3. **Aggregated_Event_Repository::upsert()** — unit tested with a mocked `wpdb`; verified correct `INSERT … ON DUPLICATE KEY UPDATE value = value + VALUES(value)` SQL is prepared, returns `true` on success and `false` on failure, JSON-encodes meta, encodes empty dimensions as `'{}'`, and sorts dimension keys alphabetically for a deterministic SHA2 hash.

4. **Event_Registry::get_event_category()** — unit tested: defaults to `'singular'` when the key is absent, returns `'aggregated'` when explicitly set, and ignores unknown values.

5. **Tracker refactoring** — all 4 trackers (Post, User, Comment, Update) continue to pass their existing unit test suites after extending `Abstract_Singular_Event` and removing duplicated constructor/filter/create boilerplate.

### How to test

1. Clone the repo and check out `feat/abstract-event-classes`.
2. In `lib/`, run `composer install`.
3. Run `composer test` — all 107 tests must pass (Unit + Integration suites).
4. Run `composer phpstan` — no new PHPStan errors.
5. Run `composer phpcs` — no PHPCS violations.
6. To verify the new DB table: activate the sybgo plugin on a WordPress install, then run `wp db query "DESCRIBE wp_sybgo_aggregated_events"` — the table must exist with columns `id`, `event_type`, `dimensions`, `dimensions_hash`, `value`, `date`, `meta` and a `UNIQUE KEY` on `(event_type, dimensions_hash, date)`.
7. To verify factory: call `Sybgo\Factory::create_aggregated_event_repository()` in a custom script — it must return an `Aggregated_Event_Repository` instance (singleton).
8. To verify dimension accumulation: call `upsert('page_view', date('Y-m-d'), 1.0, ['post_id' => 42])` twice — the resulting row must have `value = 2.0000`, not two separate rows.

### Affected Features & Quality Assurance Scope

- All 4 event trackers (Post, User, Comment, Update) — behavior unchanged, only internal structure refactored.
- `Event_Registry` — new `get_event_category()` method; existing methods unaffected.
- Database schema — additive only: new `wp_sybgo_aggregated_events` table created by `DatabaseManager::create_tables()`.
- Factory singleton pattern — new `create_aggregated_event_repository()` factory method added.

## Technical description

### Documentation

The implementation introduces a two-class tracker hierarchy under `lib/events/abstracts/`:

- **`Abstract_Singular_Event`** — all 4 built-in trackers extend this. Its constructor auto-registers the `sybgo_event_types` filter. `record()` centralises the filter/persist/action pattern. `is_throttled()` centralises the time-window check used by `Post_Tracker`.
- **`Abstract_Aggregated_Event`** — for trackers that accumulate daily values. `increment(string $event_type, float $value = 1.0, array $dimensions = [], array $meta = [])` delegates to `Aggregated_Event_Repository::upsert()` with today's date. Supports simple counts (default `$value = 1.0`), decimal sums (e.g. `249.95` for revenue), and multi-axis breakdowns via `$dimensions`.

`Aggregated_Event_Repository::upsert()` uses `INSERT … ON DUPLICATE KEY UPDATE value = value + VALUES(value)` so each `(event_type, dimensions_hash, date)` tuple accumulates atomically. `dimensions_hash` is a MySQL-generated `SHA2(dimensions, 256)` column — computed automatically, requiring no application-side hashing. Dimensions are serialised to canonical JSON (keys sorted with `ksort()` + `JSON_FORCE_OBJECT`) before storage.

`Event_Registry::get_event_category()` reads the `category` key registered on the `sybgo_event_types` filter. Defaults to `'singular'`; returns `'aggregated'` only when explicitly set.

See updated docs: `lib/docs/event-tracking.md` (Tracker Class Hierarchy, Event Categories, DB schema, use-case examples and SQL queries) and `lib/docs/extension-api.md` (`category` key for custom event types).

### New dependencies

None.

### Risks

- **DB schema addition**: `wp_sybgo_aggregated_events` is a new table created via `dbDelta()`. This is additive and safe; no existing data is touched. Risk: low.
- **Tracker refactoring**: All trackers extend the new abstract class and their public interfaces are unchanged. Existing hooks and filters fire identically. Risk: low.
- **Generated column**: `dimensions_hash GENERATED ALWAYS AS (SHA2(...)) STORED` requires MySQL 5.7+ — WordPress minimum is 5.7.8. Risk: negligible.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all checklist items apply and are satisfied.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)