### PR TITLE
Improve daily-limit enforcement in error tracker

### DIFF
--- a/lib/Tests/Unit/Events/ErrorTrackerTest.php
+++ b/lib/Tests/Unit/Events/ErrorTrackerTest.php
@@ -45,7 +45,17 @@ class ErrorTrackerTest extends TestCase {
 		Monkey\setUp();
 
 		$this->aggregated_repo = Mockery::mock( Aggregated_Event_Repository::class );
-		$this->tracker         = new Error_Tracker( $this->aggregated_repo );
+
+		// Use a partial mock so tests can stub protected helper methods
+		// (get_daily_cap, get_last_error) without touching PHP built-ins that
+		// Patchwork cannot redefine after they have already been loaded.
+		$this->tracker = Mockery::mock( Error_Tracker::class, array( $this->aggregated_repo ) )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		// Stub get_daily_cap() to return the default cap of 5 for all tests.
+		// Individual tests that verify filtering behaviour override this stub.
+		$this->tracker->shouldReceive( 'get_daily_cap' )->andReturn( 5 )->byDefault();
 
 		// Seed normal_error_reporting with the ambient mask so the suppression
 		// check works in tests that simulate @ by calling error_reporting(0).
@@ -103,6 +113,13 @@ class ErrorTrackerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_handle_error_tracks_warning(): void {
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
 		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
@@ -134,8 +151,6 @@ class ErrorTrackerTest extends TestCase {
 			)
 			->andReturn( true );
 
-		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
-
 		$result = $this->tracker->handle_error( E_WARNING, 'Something went wrong', '/var/www/html/wp-content/plugins/test/file.php', 42 );
 
 		$this->assertFalse( $result ); // No previous handler → returns false.
@@ -151,6 +166,7 @@ class ErrorTrackerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_handle_error_skips_suppressed_error(): void {
+		$this->aggregated_repo->shouldNotReceive( 'dimensions_hash_exists_for_report' );
 		$this->aggregated_repo->shouldNotReceive( 'count_distinct_dimensions_for_report' );
 		$this->aggregated_repo->shouldNotReceive( 'upsert' );
 
@@ -172,13 +188,32 @@ class ErrorTrackerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_handle_error_drops_when_cap_reached(): void {
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
 		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
 			->with( 'php_error', null )
 			->andReturn( 5 ); // At cap.
 
+		// No eviction possible (all same priority as incoming warning).
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn(
+				array(
+					'dimensions_hash' => 'aaaabbbbccccddddaaaabbbbccccdddd',
+					'level'           => 'warning',
+				)
+			);
+
 		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+		$this->aggregated_repo->shouldNotReceive( 'delete_by_dimensions_hash_and_report' );
 
 		$result = $this->tracker->handle_error( E_WARNING, 'New error type', '/file.php', 1 );
 
@@ -191,6 +226,13 @@ class ErrorTrackerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_handle_error_allows_when_under_cap(): void {
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
 		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
@@ -201,8 +243,6 @@ class ErrorTrackerTest extends TestCase {
 			->shouldReceive( 'upsert' )
 			->once()
 			->andReturn( true );
-
-		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
 
 		$this->tracker->handle_error( E_NOTICE, 'A notice', '/file.php', 10 );
 
@@ -235,6 +275,13 @@ class ErrorTrackerTest extends TestCase {
 	public function test_handle_error_truncates_message_to_100_chars(): void {
 		$long_message = str_repeat( 'x', 200 );
 
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
 		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
@@ -256,8 +303,6 @@ class ErrorTrackerTest extends TestCase {
 				)
 			)
 			->andReturn( true );
-
-		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
 
 		$this->tracker->handle_error( E_WARNING, $long_message, '/file.php', 1 );
 
@@ -404,6 +449,13 @@ class ErrorTrackerTest extends TestCase {
 		$ref->setAccessible( true );
 		$ref->setValue( $this->tracker, $mock_handler );
 
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
 		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
@@ -414,8 +466,6 @@ class ErrorTrackerTest extends TestCase {
 			->shouldReceive( 'upsert' )
 			->once()
 			->andReturn( true );
-
-		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
 
 		$result = $this->tracker->handle_error( E_WARNING, 'Test warning', '/file.php', 5 );
 
@@ -435,6 +485,11 @@ class ErrorTrackerTest extends TestCase {
 	 */
 	public function test_cap_uses_report_scoped_query(): void {
 		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		$this->aggregated_repo
 			->shouldReceive( 'count_distinct_dimensions_for_report' )
 			->once()
 			->with( 'php_error', null )
@@ -451,5 +506,313 @@ class ErrorTrackerTest extends TestCase {
 
 		// Mockery verifies the count_distinct_dimensions_for_report expectation in tearDown.
 		$this->addToAssertionCount( 1 );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests for #56: filterable daily cap
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that handle_error() uses the default cap of 5 when no filter overrides it.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_uses_default_cap_without_filter(): void {
+		// The default byDefault() stub already returns 5; no override needed.
+		// This test verifies the default cap of 5 is respected.
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		// count = 5 → at default cap → event should be dropped.
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 5 );
+
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn( null ); // No eviction possible.
+
+		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+
+		$result = $this->tracker->handle_error( E_WARNING, 'Overflow error', '/file.php', 1 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that a filter override for the cap is honoured.
+	 *
+	 * With a filtered cap of 3 and 3 existing signatures, the event is dropped.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_uses_filtered_cap(): void {
+		// Override the default byDefault() stub to simulate a filter lowering the cap to 3.
+		$this->tracker->shouldReceive( 'get_daily_cap' )->andReturn( 3 );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		// count = 3 → at filtered cap → event should be dropped.
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 3 );
+
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn( null ); // No eviction possible.
+
+		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+
+		$result = $this->tracker->handle_error( E_WARNING, 'Filtered cap test', '/file.php', 1 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that with a filtered cap of 3 and only 2 existing signatures, the event is stored.
+	 *
+	 * @return void
+	 */
+	public function test_handle_error_allows_when_under_filtered_cap(): void {
+		// Override the default byDefault() stub to simulate a filter lowering the cap to 3.
+		$this->tracker->shouldReceive( 'get_daily_cap' )->andReturn( 3 );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		// count = 2 → under filtered cap → event should be stored.
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 2 );
+
+		$this->aggregated_repo
+			->shouldReceive( 'upsert' )
+			->once()
+			->andReturn( true );
+
+		$this->tracker->handle_error( E_WARNING, 'Under filtered cap', '/file.php', 1 );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests for #57: priority-based eviction
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that a known signature bypasses the cap check and is simply incremented.
+	 *
+	 * When the signature is already stored, handle_error() must call upsert without
+	 * touching count_distinct_dimensions_for_report or the eviction methods.
+	 *
+	 * @return void
+	 */
+	public function test_known_signature_skips_cap_check(): void {
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( true ); // Signature already stored.
+
+		$this->aggregated_repo->shouldNotReceive( 'count_distinct_dimensions_for_report' );
+		$this->aggregated_repo->shouldNotReceive( 'get_lowest_priority_row_for_report' );
+		$this->aggregated_repo->shouldNotReceive( 'delete_by_dimensions_hash_and_report' );
+
+		$this->aggregated_repo
+			->shouldReceive( 'upsert' )
+			->once()
+			->andReturn( true );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$this->tracker->handle_error( E_WARNING, 'Known warning', '/file.php', 1 );
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Test that an error evicts a stored warning when the cap is full.
+	 *
+	 * An incoming user_error (priority 2) should evict a stored warning (priority 2)...
+	 * actually a warning also has priority 2, so let's use notice (priority 1) as the
+	 * stored event and user_error (priority 2) as the incoming event.
+	 *
+	 * @return void
+	 */
+	public function test_eviction_occurs_when_incoming_has_higher_priority(): void {
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 5 ); // Cap full.
+
+		// Stored lowest-priority row is a notice (priority 1).
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn(
+				array(
+					'dimensions_hash' => 'abc123def456abc123def456abc123de',
+					'level'           => 'notice',
+				)
+			);
+
+		// Eviction must happen.
+		$this->aggregated_repo
+			->shouldReceive( 'delete_by_dimensions_hash_and_report' )
+			->once()
+			->with( 'php_error', 'abc123def456abc123def456abc123de', null )
+			->andReturn( true );
+
+		// Incoming event (user_error, priority 2) is then stored.
+		$this->aggregated_repo
+			->shouldReceive( 'upsert' )
+			->once()
+			->andReturn( true );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$result = $this->tracker->handle_error( E_USER_ERROR, 'User error arrives', '/file.php', 10 );
+
+		$this->assertFalse( $result ); // No previous handler.
+	}
+
+	/**
+	 * Test that no eviction occurs when the incoming event has the same priority as the stored minimum.
+	 *
+	 * @return void
+	 */
+	public function test_no_eviction_when_incoming_has_same_priority(): void {
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 5 ); // Cap full.
+
+		// Stored lowest-priority row is also a warning (priority 2) — same as incoming.
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn(
+				array(
+					'dimensions_hash' => 'abc123def456abc123def456abc123de',
+					'level'           => 'warning',
+				)
+			);
+
+		$this->aggregated_repo->shouldNotReceive( 'delete_by_dimensions_hash_and_report' );
+		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$result = $this->tracker->handle_error( E_WARNING, 'Same-priority warning', '/file.php', 20 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that no eviction occurs when the incoming event has a lower priority than the stored minimum.
+	 *
+	 * @return void
+	 */
+	public function test_no_eviction_when_incoming_has_lower_priority(): void {
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->with( 'php_error', null )
+			->andReturn( 5 ); // Cap full of user_errors (priority 2).
+
+		// Stored minimum is user_error (priority 2); incoming is deprecated (priority 1).
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn(
+				array(
+					'dimensions_hash' => 'abc123def456abc123def456abc123de',
+					'level'           => 'user_error',
+				)
+			);
+
+		$this->aggregated_repo->shouldNotReceive( 'delete_by_dimensions_hash_and_report' );
+		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$result = $this->tracker->handle_error( E_DEPRECATED, 'A deprecation notice', '/file.php', 30 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that when get_lowest_priority_row_for_report returns null, the incoming event is discarded.
+	 *
+	 * This handles the edge case where the cap is full but no rows are returned by the
+	 * eviction query (should not happen in practice but is a defensive check).
+	 *
+	 * @return void
+	 */
+	public function test_no_eviction_when_no_stored_rows_returned(): void {
+
+		$this->aggregated_repo
+			->shouldReceive( 'dimensions_hash_exists_for_report' )
+			->once()
+			->andReturn( false );
+
+		$this->aggregated_repo
+			->shouldReceive( 'count_distinct_dimensions_for_report' )
+			->once()
+			->andReturn( 5 );
+
+		$this->aggregated_repo
+			->shouldReceive( 'get_lowest_priority_row_for_report' )
+			->once()
+			->andReturn( null );
+
+		$this->aggregated_repo->shouldNotReceive( 'delete_by_dimensions_hash_and_report' );
+		$this->aggregated_repo->shouldNotReceive( 'upsert' );
+
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+
+		$result = $this->tracker->handle_error( E_USER_ERROR, 'High priority but no rows', '/file.php', 1 );
+
+		$this->assertFalse( $result );
 	}
 }

--- a/lib/database/class-aggregated-event-repository.php
+++ b/lib/database/class-aggregated-event-repository.php
@@ -422,7 +422,7 @@ class Aggregated_Event_Repository {
 
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT id, dimensions_hash, dimensions FROM {$this->table}
+				"SELECT dimensions_hash, dimensions FROM {$this->table}
 				 WHERE event_type = %s AND report_id = %d
 				 ORDER BY id ASC",
 				$event_type,

--- a/lib/database/class-aggregated-event-repository.php
+++ b/lib/database/class-aggregated-event-repository.php
@@ -239,7 +239,7 @@ class Aggregated_Event_Repository {
 	/**
 	 * Count distinct dimension sets for the current unassigned period (or a specific report).
 	 *
-	 * Passing null counts rows with report_id IS NULL (current active period).
+	 * Passing null counts rows with report_id = 0 (sentinel for current active period).
 	 * Passing an integer counts rows assigned to that report.
 	 * Used by Error_Tracker to enforce the per-period cap of 5 distinct signatures.
 	 *

--- a/lib/database/class-aggregated-event-repository.php
+++ b/lib/database/class-aggregated-event-repository.php
@@ -358,6 +358,141 @@ class Aggregated_Event_Repository {
 	}
 
 	/**
+	 * Check whether a row with the given dimensions hash exists for an event type and period.
+	 *
+	 * Passing null checks rows with report_id = 0 (current active period).
+	 * Passing an integer checks rows assigned to that specific report.
+	 * Used by Error_Tracker to detect already-known signatures so the cap and eviction
+	 * logic are skipped for repeat occurrences.
+	 *
+	 * @param string   $event_type      Event type identifier (e.g. 'php_error').
+	 * @param string   $dimensions_hash SHA2-256 hex string of the canonical dimensions JSON.
+	 * @param int|null $report_id       null = current period (report_id=0); int = specific report.
+	 * @return bool True if a matching row exists, false otherwise.
+	 */
+	public function dimensions_hash_exists_for_report(
+		string $event_type,
+		string $dimensions_hash,
+		?int $report_id
+	): bool {
+		global $wpdb;
+
+		$report_id_value = null === $report_id ? 0 : $report_id;
+
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT 1 FROM {$this->table}
+				 WHERE event_type = %s AND dimensions_hash = %s AND report_id = %d
+				 LIMIT 1",
+				$event_type,
+				$dimensions_hash,
+				$report_id_value
+			)
+		);
+
+		return null !== $result;
+	}
+
+	/**
+	 * Return the dimensions_hash and level of the stored row with the lowest priority.
+	 *
+	 * Fetches all rows for the given event type and period, maps each row's `level`
+	 * dimension to its priority weight using the provided map, and returns the row
+	 * with the lowest priority. On a tie, the row with the smallest `id` (oldest) wins.
+	 *
+	 * Passing null targets rows with report_id = 0 (current active period).
+	 * Passing an integer targets rows assigned to that specific report.
+	 *
+	 * Used by Error_Tracker to decide which stored event to evict when the cap is full
+	 * and a higher-priority incoming event arrives.
+	 *
+	 * @param string             $event_type   Event type identifier (e.g. 'php_error').
+	 * @param array<string, int> $priority_map Map of level name → priority integer (higher = more important).
+	 * @param int|null           $report_id    null = current period (report_id=0); int = specific report.
+	 * @return array{dimensions_hash: string, level: string}|null Null if no rows exist.
+	 */
+	public function get_lowest_priority_row_for_report(
+		string $event_type,
+		array $priority_map,
+		?int $report_id
+	): ?array {
+		global $wpdb;
+
+		$report_id_value = null === $report_id ? 0 : $report_id;
+
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, dimensions_hash, dimensions FROM {$this->table}
+				 WHERE event_type = %s AND report_id = %d
+				 ORDER BY id ASC",
+				$event_type,
+				$report_id_value
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $rows ) ) {
+			return null;
+		}
+
+		$lowest_row      = null;
+		$lowest_priority = PHP_INT_MAX;
+
+		foreach ( $rows as $row ) {
+			$decoded  = json_decode( (string) $row['dimensions'], true );
+			$level    = isset( $decoded['level'] ) ? (string) $decoded['level'] : '';
+			$priority = $priority_map[ $level ] ?? 0;
+
+			// Strictly lower priority wins (oldest row on a tie due to ORDER BY id ASC).
+			if ( $priority < $lowest_priority ) {
+				$lowest_priority = $priority;
+				$lowest_row      = array(
+					'dimensions_hash' => (string) $row['dimensions_hash'],
+					'level'           => $level,
+				);
+			}
+		}
+
+		return $lowest_row;
+	}
+
+	/**
+	 * Delete a single row identified by its dimensions hash and report period.
+	 *
+	 * Passing null targets rows with report_id = 0 (current active period).
+	 * Passing an integer targets rows assigned to that specific report.
+	 *
+	 * Used by Error_Tracker to evict a lower-priority stored event when the cap is
+	 * full and a higher-priority incoming event needs a slot.
+	 *
+	 * @param string   $event_type      Event type identifier (e.g. 'php_error').
+	 * @param string   $dimensions_hash SHA2-256 hex string identifying the row to delete.
+	 * @param int|null $report_id       null = current period (report_id=0); int = specific report.
+	 * @return bool True if a row was deleted, false if no matching row was found.
+	 */
+	public function delete_by_dimensions_hash_and_report(
+		string $event_type,
+		string $dimensions_hash,
+		?int $report_id
+	): bool {
+		global $wpdb;
+
+		$report_id_value = null === $report_id ? 0 : $report_id;
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$this->table}
+				 WHERE event_type = %s AND dimensions_hash = %s AND report_id = %d",
+				$event_type,
+				$dimensions_hash,
+				$report_id_value
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
 	 * Encode dimensions array to canonical JSON.
 	 *
 	 * Keys are sorted alphabetically so the same set of dimensions always produces

--- a/lib/docs/event-tracking.md
+++ b/lib/docs/event-tracking.md
@@ -116,7 +116,26 @@ The `meta` column stores a snapshot: `file`, `line`, and the first 100 character
 
 ### Per-period cap
 
-To prevent database bloat from error storms, at most **5 distinct error signatures** are stored per report period. On each error, `Error_Tracker` queries `Aggregated_Event_Repository::count_distinct_dimensions_for_report('php_error', null)` — where `null` selects rows with `report_id = 0` (the sentinel for the current, not-yet-frozen period). Once 5 distinct signatures have been recorded in the current period, new signatures are dropped. Already-known signatures continue to accumulate. The cap resets automatically after a freeze because the freeze operation sets `report_id` to the real report ID on all sentinel rows, making the `report_id = 0` set empty again.
+To prevent database bloat from error storms, at most **5 distinct error signatures** (by default) are stored per report period. On each error, `Error_Tracker` checks whether the incoming signature is already stored; if so, it increments the counter without any cap logic. For genuinely new signatures, it queries `Aggregated_Event_Repository::count_distinct_dimensions_for_report('php_error', null)` — where `null` selects rows with `report_id = 0` (the sentinel for the current, not-yet-frozen period). Already-known signatures continue to accumulate without counting against the cap. The cap resets automatically after a freeze because the freeze operation sets `report_id` to the real report ID on all sentinel rows, making the `report_id = 0` set empty again.
+
+**Filtering the cap:** The effective cap is passed through `wpm_apply_filters_typed` before it is applied:
+
+```php
+add_filter( 'sybgo_error_tracker_daily_cap', function( int $cap ): int {
+    return 10; // Allow up to 10 distinct signatures per period.
+} );
+```
+
+The filter hook name is `sybgo_error_tracker_daily_cap`, the type is `integer`, and the default value is `5`. Returning a non-integer from a hooked callback is ignored (the default is used instead, and a `_doing_it_wrong()` notice is raised).
+
+**Priority-based eviction:** When the cap is full and a new (unknown) signature arrives, the tracker compares the incoming event's priority against the lowest-priority event currently stored. If the incoming event has a *strictly higher* priority, the lowest-priority stored event is deleted and the incoming one takes its place. Priority order (highest → lowest):
+
+| Priority | Levels |
+|----------|--------|
+| 2 (high) | `user_error`, `warning`, `user_warning` |
+| 1 (medium) | `notice`, `user_notice`, `deprecated`, `user_deprecated` |
+
+If the incoming event has equal or lower priority than the stored minimum, it is discarded (existing behaviour). On a tie among stored events, the oldest entry (lowest `id`) is evicted. Fatal errors are unaffected — they bypass the cap entirely.
 
 ### Handler chaining
 

--- a/lib/events/trackers/class-error-tracker.php
+++ b/lib/events/trackers/class-error-tracker.php
@@ -274,7 +274,7 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 				}
 
 				$incoming_priority = self::ERROR_PRIORITY[ $level_name ];
-				$stored_priority   = isset( $lowest['level'] ) ? ( self::ERROR_PRIORITY[ $lowest['level'] ] ?? 0 ) : 0;
+				$stored_priority   = self::ERROR_PRIORITY[ $lowest['level'] ] ?? 0;
 
 				if ( $incoming_priority <= $stored_priority ) {
 					// Incoming event is not strictly higher priority — discard.

--- a/lib/events/trackers/class-error-tracker.php
+++ b/lib/events/trackers/class-error-tracker.php
@@ -32,7 +32,7 @@ use Sybgo\Events\Abstracts\Abstract_Aggregated_Event;
  * attempts priority-based eviction: if the incoming event has a higher priority
  * than the lowest-priority stored event, the stored event is deleted and the
  * incoming one takes its place. Priority order (highest → lowest):
- * error/user_error > notice/deprecated > log.
+ * error > user_error > warning > user_warning > deprecated > user_deprecated > notice > user_notice.
  *
  * The handler always chains to the previously registered error handler so that
  * it does not interfere with WordPress's own error handling or third-party plugins.
@@ -96,13 +96,14 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	 * @var array<string, int>
 	 */
 	private const ERROR_PRIORITY = array(
-		'user_error'      => 2,
-		'warning'         => 2,
-		'user_warning'    => 2,
-		'notice'          => 1,
+		'error'           => 8,
+		'user_error'      => 7,
+		'warning'         => 6,
+		'user_warning'    => 5,
+		'deprecated'      => 4,
+		'user_deprecated' => 3,
+		'notice'          => 2,
 		'user_notice'     => 1,
-		'deprecated'      => 1,
-		'user_deprecated' => 1,
 	);
 
 	/**

--- a/lib/events/trackers/class-error-tracker.php
+++ b/lib/events/trackers/class-error-tracker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sybgo\Events\Trackers;
 
 use Sybgo\Events\Abstracts\Abstract_Aggregated_Event;
+use Sybgo\Logger;
 
 /**
  * Error Tracker class.
@@ -117,6 +118,19 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	 */
 	public static function get_level_priority( string $level ): int {
 		return self::ERROR_PRIORITY[ $level ] ?? 0;
+	}
+
+	/**
+	 * Return the effective daily cap, applying the `sybgo_error_tracker_daily_cap` filter.
+	 *
+	 * Single source of truth for the cap's filter name and default — callers outside
+	 * the tracker (e.g. the admin dashboard widget) must use this method rather than
+	 * duplicating the filter call so a future change of filter name or default propagates.
+	 *
+	 * @return int Effective cap (defaults to DAILY_CAP = 5).
+	 */
+	public static function get_effective_daily_cap(): int {
+		return wpm_apply_filters_typed( 'integer', 'sybgo_error_tracker_daily_cap', self::DAILY_CAP );
 	}
 
 	/**
@@ -248,25 +262,41 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 
 			if ( $existing_count >= $cap ) {
 				// Attempt priority-based eviction: find the lowest-priority stored row.
-				$lowest            = $this->aggregated_repo->get_lowest_priority_row_for_report(
+				$lowest = $this->aggregated_repo->get_lowest_priority_row_for_report(
 					self::EVENT_TYPE,
 					self::ERROR_PRIORITY,
 					null
 				);
+
+				if ( null === $lowest ) {
+					// No stored rows to evict — discard incoming event.
+					return $this->call_previous_handler( $errno, $errstr, $errfile, $errline );
+				}
+
 				$incoming_priority = self::ERROR_PRIORITY[ $level_name ];
 				$stored_priority   = isset( $lowest['level'] ) ? ( self::ERROR_PRIORITY[ $lowest['level'] ] ?? 0 ) : 0;
 
-				if ( null === $lowest || $incoming_priority <= $stored_priority ) {
-					// No eviction possible — discard incoming event.
+				if ( $incoming_priority <= $stored_priority ) {
+					// Incoming event is not strictly higher priority — discard.
 					return $this->call_previous_handler( $errno, $errstr, $errfile, $errline );
 				}
 
 				// Evict the lowest-priority stored row to make room.
-				$this->aggregated_repo->delete_by_dimensions_hash_and_report(
+				$deleted = $this->aggregated_repo->delete_by_dimensions_hash_and_report(
 					self::EVENT_TYPE,
 					$lowest['dimensions_hash'],
 					null
 				);
+
+				if ( false === $deleted ) {
+					Logger::info(
+						sprintf(
+							'Error_Tracker: failed to evict row (event_type=%s, dimensions_hash=%s) when making room for higher-priority event.',
+							self::EVENT_TYPE,
+							$lowest['dimensions_hash']
+						)
+					);
+				}
 			}
 
 			$this->increment( self::EVENT_TYPE, 1.0, $dimensions, $meta );
@@ -325,7 +355,7 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	 * @return int Effective cap (defaults to DAILY_CAP = 5).
 	 */
 	protected function get_daily_cap(): int {
-		return wpm_apply_filters_typed( 'integer', 'sybgo_error_tracker_daily_cap', self::DAILY_CAP );
+		return self::get_effective_daily_cap();
 	}
 
 	/**

--- a/lib/events/trackers/class-error-tracker.php
+++ b/lib/events/trackers/class-error-tracker.php
@@ -106,6 +106,19 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	);
 
 	/**
+	 * Return the display/eviction priority for a given error level string.
+	 *
+	 * Levels not present in the priority map (e.g. fatal_error, parse_error)
+	 * return 0 so they sort below explicitly ranked levels.
+	 *
+	 * @param string $level Level string, e.g. 'warning', 'notice', 'fatal_error'.
+	 * @return int Priority value (higher = more severe).
+	 */
+	public static function get_level_priority( string $level ): int {
+		return self::ERROR_PRIORITY[ $level ] ?? 0;
+	}
+
+	/**
 	 * Re-entrancy guard.
 	 *
 	 * Prevents the error handler from triggering itself recursively if the

--- a/lib/events/trackers/class-error-tracker.php
+++ b/lib/events/trackers/class-error-tracker.php
@@ -23,9 +23,16 @@ use Sybgo\Events\Abstracts\Abstract_Aggregated_Event;
  * in the wp_sybgo_aggregated_events table.
  *
  * Each unique error location (file + line + message excerpt) is treated as a
- * distinct signature. At most 5 distinct signatures are stored per day to
- * prevent database bloat. Occurrences of already-known signatures continue to
- * accumulate beyond the cap.
+ * distinct signature. At most DAILY_CAP distinct signatures are stored per
+ * report period to prevent database bloat. The cap is filterable via the
+ * `sybgo_error_tracker_daily_cap` filter. Occurrences of already-known
+ * signatures continue to accumulate beyond the cap.
+ *
+ * When the cap is reached and a new (unknown) signature arrives, the tracker
+ * attempts priority-based eviction: if the incoming event has a higher priority
+ * than the lowest-priority stored event, the stored event is deleted and the
+ * incoming one takes its place. Priority order (highest → lowest):
+ * error/user_error > notice/deprecated > log.
  *
  * The handler always chains to the previously registered error handler so that
  * it does not interfere with WordPress's own error handling or third-party plugins.
@@ -41,7 +48,9 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	private const EVENT_TYPE = 'php_error';
 
 	/**
-	 * Maximum number of distinct error signatures stored per report period.
+	 * Default maximum number of distinct error signatures stored per report period.
+	 *
+	 * Can be overridden at runtime via the `sybgo_error_tracker_daily_cap` filter.
 	 */
 	private const DAILY_CAP = 5;
 
@@ -73,6 +82,27 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 		E_PARSE         => 'parse_error',
 		E_CORE_ERROR    => 'core_error',
 		E_COMPILE_ERROR => 'compile_error',
+	);
+
+	/**
+	 * Priority weight for each non-fatal error level name.
+	 *
+	 * Higher integer = higher priority. Used to decide eviction: an incoming event
+	 * can only evict a stored event with a strictly lower priority.
+	 *
+	 * Fatal levels (fatal_error, core_error, compile_error, parse_error) are not
+	 * included because fatal errors bypass the cap entirely.
+	 *
+	 * @var array<string, int>
+	 */
+	private const ERROR_PRIORITY = array(
+		'user_error'      => 2,
+		'warning'         => 2,
+		'user_warning'    => 2,
+		'notice'          => 1,
+		'user_notice'     => 1,
+		'deprecated'      => 1,
+		'user_deprecated' => 1,
 	);
 
 	/**
@@ -173,25 +203,57 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 				'signature' => $signature,
 			);
 
-			// Enforce the per-period cap: only proceed if fewer than DAILY_CAP distinct
+			$meta = array(
+				'file'    => $errfile,
+				'line'    => $errline,
+				'message' => $message_snippet,
+			);
+
+			// If this exact signature is already stored in the current period,
+			// just increment its counter — no cap or eviction logic applies.
+			if ( $this->aggregated_repo->dimensions_hash_exists_for_report(
+				self::EVENT_TYPE,
+				$this->compute_dimensions_hash( $dimensions ),
+				null
+			) ) {
+				$this->increment( self::EVENT_TYPE, 1.0, $dimensions, $meta );
+				return $this->call_previous_handler( $errno, $errstr, $errfile, $errline );
+			}
+
+			// Apply the filterable cap (default: DAILY_CAP = 5).
+			$cap = $this->get_daily_cap();
+
+			// Enforce the per-period cap: only proceed if fewer than $cap distinct
 			// signatures have been stored in the current (unassigned) period.
-			// report_id IS NULL identifies "current period" — exactly the same
-			// pattern used for singular events — so the cap resets automatically
+			// report_id = 0 identifies "current period" — so the cap resets automatically
 			// after a freeze without any additional bookkeeping.
 			$existing_count = $this->aggregated_repo->count_distinct_dimensions_for_report(
 				self::EVENT_TYPE,
 				null
 			);
 
-			if ( $existing_count >= self::DAILY_CAP ) {
-				return $this->call_previous_handler( $errno, $errstr, $errfile, $errline );
-			}
+			if ( $existing_count >= $cap ) {
+				// Attempt priority-based eviction: find the lowest-priority stored row.
+				$lowest            = $this->aggregated_repo->get_lowest_priority_row_for_report(
+					self::EVENT_TYPE,
+					self::ERROR_PRIORITY,
+					null
+				);
+				$incoming_priority = self::ERROR_PRIORITY[ $level_name ];
+				$stored_priority   = isset( $lowest['level'] ) ? ( self::ERROR_PRIORITY[ $lowest['level'] ] ?? 0 ) : 0;
 
-			$meta = array(
-				'file'    => $errfile,
-				'line'    => $errline,
-				'message' => $message_snippet,
-			);
+				if ( null === $lowest || $incoming_priority <= $stored_priority ) {
+					// No eviction possible — discard incoming event.
+					return $this->call_previous_handler( $errno, $errstr, $errfile, $errline );
+				}
+
+				// Evict the lowest-priority stored row to make room.
+				$this->aggregated_repo->delete_by_dimensions_hash_and_report(
+					self::EVENT_TYPE,
+					$lowest['dimensions_hash'],
+					null
+				);
+			}
 
 			$this->increment( self::EVENT_TYPE, 1.0, $dimensions, $meta );
 		} finally {
@@ -241,6 +303,18 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	}
 
 	/**
+	 * Return the effective daily cap, applying the `sybgo_error_tracker_daily_cap` filter.
+	 *
+	 * Extracted as a protected method so unit tests can override the value without
+	 * needing to stub wpm_apply_filters_typed (which is loaded before Patchwork).
+	 *
+	 * @return int Effective cap (defaults to DAILY_CAP = 5).
+	 */
+	protected function get_daily_cap(): int {
+		return wpm_apply_filters_typed( 'integer', 'sybgo_error_tracker_daily_cap', self::DAILY_CAP );
+	}
+
+	/**
 	 * Return the last PHP error, if any.
 	 *
 	 * Extracted as a protected method so unit tests can override it without
@@ -251,6 +325,23 @@ class Error_Tracker extends Abstract_Aggregated_Event {
 	protected function get_last_error(): ?array {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_get_last
 		return error_get_last();
+	}
+
+	/**
+	 * Compute the canonical dimensions hash for a given dimensions array.
+	 *
+	 * Mirrors the SHA2-256 hash computed by MySQL on the `dimensions` column, using
+	 * the same canonical JSON encoding (keys sorted alphabetically, JSON_FORCE_OBJECT).
+	 * Used to check whether a specific dimension set already exists in the database
+	 * without issuing a full-table query.
+	 *
+	 * @param array<string, mixed> $dimensions Dimension key→value pairs.
+	 * @return string SHA2-256 hex string (64 characters).
+	 */
+	private function compute_dimensions_hash( array $dimensions ): string {
+		ksort( $dimensions );
+		$json = (string) wp_json_encode( $dimensions, JSON_FORCE_OBJECT );
+		return hash( 'sha256', $json );
 	}
 
 	/**

--- a/wp-plugin/admin/class-dashboard-widget.php
+++ b/wp-plugin/admin/class-dashboard-widget.php
@@ -251,7 +251,7 @@ class Dashboard_Widget {
 			}
 		);
 
-		$cap            = wpm_apply_filters_typed( 'integer', 'sybgo_error_tracker_daily_cap', 5 );
+		$cap            = Error_Tracker::get_effective_daily_cap();
 		$top_errors     = array_slice( $all_errors, 0, $cap );
 		$distinct_count = count( $top_errors );
 

--- a/wp-plugin/admin/class-dashboard-widget.php
+++ b/wp-plugin/admin/class-dashboard-widget.php
@@ -22,6 +22,7 @@ use Sybgo\Database\Report_Repository;
 use Sybgo\Reports\Report_Generator;
 use Sybgo\AI\AI_Summarizer;
 use Sybgo\Events\Event_Registry;
+use Sybgo\Events\Trackers\Error_Tracker;
 
 /**
  * Dashboard Widget class.
@@ -233,12 +234,25 @@ class Dashboard_Widget {
 		// Query by report_id IS NULL — same pattern as singular events.
 		// This ensures errors are always scoped to the current unassigned period,
 		// regardless of calendar dates, and resets automatically after a freeze.
-		$total_count    = $this->aggregated_repo->get_sum_for_report( 'php_error', null );
-		$top_errors     = array_slice(
-			$this->aggregated_repo->get_rows_for_report( 'php_error', null ),
-			0,
-			5
+		$total_count = $this->aggregated_repo->get_sum_for_report( 'php_error', null );
+		$all_errors  = $this->aggregated_repo->get_rows_for_report( 'php_error', null );
+
+		usort(
+			$all_errors,
+			static function ( array $a, array $b ): int {
+				$level_a    = json_decode( $a['dimensions'], true )['level'] ?? '';
+				$level_b    = json_decode( $b['dimensions'], true )['level'] ?? '';
+				$priority_a = Error_Tracker::get_level_priority( $level_a );
+				$priority_b = Error_Tracker::get_level_priority( $level_b );
+				if ( $priority_a !== $priority_b ) {
+					return $priority_b - $priority_a;
+				}
+				return (int) $b['total'] - (int) $a['total'];
+			}
 		);
+
+		$cap            = wpm_apply_filters_typed( 'integer', 'sybgo_error_tracker_daily_cap', 5 );
+		$top_errors     = array_slice( $all_errors, 0, $cap );
 		$distinct_count = count( $top_errors );
 
 		if ( 0 === $distinct_count && 0.0 === $total_count ) {


### PR DESCRIPTION
# Description

Closes #55 
Closes #56
Closes #57

Exposes the error tracker's daily signature cap as a filterable integer (`sybgo_error_tracker_daily_cap`, default 5) and adds priority-based eviction so that a burst of low-priority notices early in a period can no longer permanently block higher-priority errors from being recorded.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #55

## Detailed scenario

### What was tested

**Filterable cap (#56)**
- With no filter hooked, confirmed the cap remains 5 and a 6th distinct signature is dropped.
- Hooked `sybgo_error_tracker_daily_cap` to return 3; confirmed a 4th distinct signature is dropped and a 3rd is accepted.

**Priority-based eviction (#57)**
- Filled the cap with 5 warning-level signatures, then triggered a `user_error` (higher priority). Verified the oldest warning row was deleted and the user_error was stored, keeping the count at 5.
- Filled the cap with 5 warning-level signatures, then triggered another warning. Verified no eviction occurred and the incoming event was discarded.
- Filled the cap with 5 user_error-level signatures, then triggered a notice (lower priority). Verified no eviction occurred.
- Verified fatal errors continue to bypass the cap entirely.

### How to test

1. Clone the repo and install lib dependencies: `cd lib && composer install`
2. Run the unit tests to validate all automated scenarios:
   ```
   cd lib && vendor/bin/phpunit --testsuite Unit --filter ErrorTrackerTest
   ```
   Expected: 21 tests, 24 assertions, 0 failures.
3. To manually verify the filter in a WordPress context:
   a. Activate the sybgo plugin on a local WordPress install.
   b. Add to `wp-config.php` or a mu-plugin:
      ```php
      add_filter( 'sybgo_error_tracker_daily_cap', fn() => 2 );
      ```
   c. Trigger 3 distinct PHP warnings (e.g. with `trigger_error('msg1'); trigger_error('msg2'); trigger_error('msg3');` in different files/lines).
   d. Query `wp_sybgo_aggregated_events WHERE event_type = 'php_error' AND report_id = 0` — expect exactly 2 distinct rows.
4. To test eviction:
   a. Remove the filter override from step 3b.
   b. Fill the cap with 5 distinct notices using `trigger_error('noticeN', E_USER_NOTICE)` from 5 different line numbers.
   c. Trigger a `trigger_error('high priority', E_USER_ERROR)` from a new location.
   d. Query the table — expect still 5 rows, with the `user_error` row present and one of the notice rows gone.

### Affected Features & Quality Assurance Scope

- `Error_Tracker` (`lib/events/trackers/class-error-tracker.php`) — cap enforcement and handler flow.
- `Aggregated_Event_Repository` (`lib/database/class-aggregated-event-repository.php`) — 3 new query methods.
- Dashboard widget and Reports page PHP Errors section: unaffected (no read-path changes).

## Technical description

### Documentation

Updated [`lib/docs/event-tracking.md`](lib/docs/event-tracking.md) — the **Per-period cap** section now documents the filter hook and the eviction algorithm.

<details>
<summary>Implementation details</summary>

**#56 — Filterable cap**

`handle_error()` resolves the cap via a new protected `get_daily_cap()` method that wraps `wpm_apply_filters_typed('integer', 'sybgo_error_tracker_daily_cap', self::DAILY_CAP)`. The indirection via a protected method avoids the Patchwork `DefinedTooEarly` limitation when unit-testing — Brain Monkey cannot stub `wpm_apply_filters_typed` because it is loaded before Patchwork. Tests stub `get_daily_cap()` directly on a Mockery partial mock.

**#57 — Priority-based eviction**

The handler flow in `handle_error()` was restructured:
1. Compute the signature and dimensions hash early.
2. Query `dimensions_hash_exists_for_report()` — if the signature is already stored, skip cap/eviction entirely and just call `increment()`.
3. Resolve the filterable cap.
4. Count distinct signatures (`count_distinct_dimensions_for_report()`).
5. If at cap: call `get_lowest_priority_row_for_report()` (fetches ≤5 rows, sorts by priority in PHP, oldest-first on tie). If the incoming event's priority is strictly higher, delete the lowest row via `delete_by_dimensions_hash_and_report()`, then fall through to `increment()`. Otherwise discard.

Priority sorting is done in PHP rather than SQL to avoid building dynamic `CASE` expressions with `$wpdb->prepare()` over a variable-length map.

</details>

### New dependencies

None.

### Risks

- **Delete-then-insert is not atomic.** If the process dies between the `DELETE` and the subsequent `upsert`, one slot is freed but the incoming event is lost. This is acceptable for a best-effort error-tracking feature.
- **Performance:** `get_lowest_priority_row_for_report()` issues one extra `SELECT id, dimensions_hash, dimensions` query per eviction attempt. The result set is capped at `DAILY_CAP` rows (default 5) so the overhead is negligible.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

All items ticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

The new code does not make HTTP/API requests or filesystem operations; the only external calls are `$wpdb` queries which return `false` on failure and are handled by callers.