### PR TITLE
Replace dashboard widget digest preview popups with report detail links

### DIFF
--- a/wp-plugin/Tests/Unit/Admin/DashboardWidgetTest.php
+++ b/wp-plugin/Tests/Unit/Admin/DashboardWidgetTest.php
@@ -124,6 +124,7 @@ class DashboardWidgetTest extends TestCase {
 	 * Widget should render the "Get AI Summary" button when AI summarizer is available.
 	 */
 	public function test_render_widget_shows_get_ai_summary_button_when_summarizer_available(): void {
+		$this->report_repo->shouldReceive( 'get_active' )->andReturn( null );
 		$this->report_repo->shouldReceive( 'get_last_frozen' )->andReturn( null );
 		$this->event_repo->shouldReceive( 'get_by_report' )->with( null )->andReturn( array() );
 		$this->aggregated_repo->shouldReceive( 'get_sum_for_report' )->andReturn( 0 );
@@ -155,6 +156,7 @@ class DashboardWidgetTest extends TestCase {
 			$aggregated_repo
 		);
 
+		$report_repo->shouldReceive( 'get_active' )->andReturn( null );
 		$report_repo->shouldReceive( 'get_last_frozen' )->andReturn( null );
 		$event_repo->shouldReceive( 'get_by_report' )->with( null )->andReturn( array() );
 		$aggregated_repo->shouldReceive( 'get_sum_for_report' )->andReturn( 0 );
@@ -175,6 +177,7 @@ class DashboardWidgetTest extends TestCase {
 	 * "Get AI Summary" button must appear before the filter buttons.
 	 */
 	public function test_render_widget_ai_button_appears_before_filter_buttons(): void {
+		$this->report_repo->shouldReceive( 'get_active' )->andReturn( null );
 		$this->report_repo->shouldReceive( 'get_last_frozen' )->andReturn( null );
 		$this->event_repo->shouldReceive( 'get_by_report' )->with( null )->andReturn( array() );
 		$this->aggregated_repo->shouldReceive( 'get_sum_for_report' )->andReturn( 0 );
@@ -279,30 +282,40 @@ class DashboardWidgetTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// ajax_preview_digest() — no longer calls AI
+	// render_widget() — report detail links
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Preview digest AJAX must not call AI summarizer.
+	 * Widget must render links to active and last frozen report detail pages when both exist.
 	 */
-	public function test_ajax_preview_digest_does_not_call_ai_summarizer(): void {
-		Functions\when( 'check_ajax_referer' )->justReturn( true );
-		Functions\when( 'current_user_can' )->justReturn( true );
-		Functions\when( 'wp_send_json_success' )->justReturn();
-		Functions\when( 'wp_send_json_error' )->justReturn();
-		Functions\when( 'absint' )->alias( 'absint' );
-
+	public function test_render_widget_shows_links_when_reports_exist(): void {
+		$this->report_repo->shouldReceive( 'get_active' )->andReturn( array( 'id' => '3', 'status' => 'active' ) );
+		$this->report_repo->shouldReceive( 'get_last_frozen' )->andReturn( array( 'id' => '1', 'status' => 'frozen' ) );
 		$this->event_repo->shouldReceive( 'get_by_report' )->with( null )->andReturn( array() );
+		$this->aggregated_repo->shouldReceive( 'get_sum_for_report' )->andReturn( 0 );
+		$this->aggregated_repo->shouldReceive( 'get_rows_for_report' )->andReturn( array() );
+
+		$output = $this->capture( 'render_widget' );
+
+		$this->assertStringContainsString( 'report_id=3', $output );
+		$this->assertStringContainsString( 'report_id=1', $output );
+		$this->assertStringContainsString( "View This Week's Details", $output );
+		$this->assertStringContainsString( "View Last Week's Details", $output );
+	}
+
+	/**
+	 * Widget must not render report detail links when no reports exist.
+	 */
+	public function test_render_widget_hides_links_when_no_reports(): void {
 		$this->report_repo->shouldReceive( 'get_active' )->andReturn( null );
-		$this->report_generator->shouldReceive( 'generate_live_summary' )
-			->andReturn( array( 'totals' => array(), 'trends' => array() ) );
+		$this->report_repo->shouldReceive( 'get_last_frozen' )->andReturn( null );
+		$this->event_repo->shouldReceive( 'get_by_report' )->with( null )->andReturn( array() );
+		$this->aggregated_repo->shouldReceive( 'get_sum_for_report' )->andReturn( 0 );
+		$this->aggregated_repo->shouldReceive( 'get_rows_for_report' )->andReturn( array() );
 
-		// AI summarizer must NOT be called.
-		$this->ai_summarizer->shouldNotReceive( 'generate_summary' );
+		$output = $this->capture( 'render_widget' );
 
-		$this->widget->ajax_preview_digest();
-
-		// Mockery expectation is the assertion; add count so PHPUnit doesn't flag as risky.
-		$this->addToAssertionCount( 1 );
+		$this->assertStringNotContainsString( 'sybgo-reports', $output );
+		$this->assertStringNotContainsString( 'report_id=', $output );
 	}
 }

--- a/wp-plugin/admin/class-dashboard-widget.php
+++ b/wp-plugin/admin/class-dashboard-widget.php
@@ -111,9 +111,7 @@ class Dashboard_Widget {
 		add_action( 'wp_dashboard_setup', array( $this, 'register_widget' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'wp_ajax_sybgo_filter_events', array( $this, 'ajax_filter_events' ) );
-		add_action( 'wp_ajax_sybgo_preview_digest', array( $this, 'ajax_preview_digest' ) );
 		add_action( 'wp_ajax_sybgo_widget_ai_summary', array( $this, 'ajax_widget_ai_summary' ) );
-		add_action( 'wp_ajax_sybgo_preview_last_digest', array( $this, 'ajax_preview_last_digest' ) );
 	}
 
 	/**
@@ -164,17 +162,24 @@ class Dashboard_Widget {
 	 */
 	public function render_widget(): void {
 		// Get current week's events (unassigned).
-		$current_events = $this->event_repo->get_by_report( null );
+		$current_events     = $this->event_repo->get_by_report( null );
+		$active_report      = $this->report_repo->get_active();
+		$last_frozen_report = $this->report_repo->get_last_frozen();
+		$details_base_url   = admin_url( 'admin.php?page=sybgo-reports&view=details&report_id=' );
 
 		?>
 		<div class="sybgo-widget">
 			<div class="sybgo-widget-actions">
-				<button type="button" class="button button-secondary sybgo-preview-btn">
-					<?php esc_html_e( 'Preview This Week\'s Digest', 'sybgo' ); ?>
-				</button>
-				<button type="button" class="button button-secondary sybgo-preview-last-btn">
-					<?php esc_html_e( 'View Previous Digest', 'sybgo' ); ?>
-				</button>
+				<?php if ( $active_report ) : ?>
+					<a href="<?php echo esc_url( $details_base_url . (int) $active_report['id'] ); ?>" class="button button-secondary">
+						<?php esc_html_e( 'View This Week\'s Details', 'sybgo' ); ?>
+					</a>
+				<?php endif; ?>
+				<?php if ( $last_frozen_report ) : ?>
+					<a href="<?php echo esc_url( $details_base_url . (int) $last_frozen_report['id'] ); ?>" class="button button-secondary">
+						<?php esc_html_e( 'View Last Week\'s Details', 'sybgo' ); ?>
+					</a>
+				<?php endif; ?>
 			</div>
 
 			<div class="sybgo-current-week">
@@ -207,14 +212,6 @@ class Dashboard_Widget {
 			</div>
 
 			<?php $this->render_php_errors_section(); ?>
-
-			<div id="sybgo-preview-modal" class="sybgo-modal" style="display:none;">
-				<div class="sybgo-modal-content">
-					<span class="sybgo-modal-close">&times;</span>
-					<h2><?php esc_html_e( 'Digest Preview', 'sybgo' ); ?></h2>
-					<div class="sybgo-modal-body"></div>
-				</div>
-			</div>
 		</div>
 		<?php
 	}
@@ -448,136 +445,6 @@ class Dashboard_Widget {
 				'count' => count( $events ),
 			)
 		);
-	}
-
-	/**
-	 * AJAX handler for preview digest.
-	 *
-	 * @return void
-	 */
-	public function ajax_preview_digest(): void {
-		try {
-			check_ajax_referer( 'sybgo_widget_nonce', 'nonce' );
-
-			if ( ! current_user_can( 'read' ) ) {
-				wp_send_json_error( array( 'message' => 'Unauthorized' ) );
-			}
-
-			// Get current week's events.
-			$events = $this->event_repo->get_by_report( null );
-
-			// Try to get active report for trends, but don't fail if it doesn't exist.
-			$active_report = $this->report_repo->get_active();
-
-			// Generate preview summary (totals + trends).
-			$live_summary = $this->report_generator->generate_live_summary(
-				$events,
-				$active_report ? (int) $active_report['id'] : 0
-			);
-			$totals       = $live_summary['totals'];
-			$trends       = $live_summary['trends'];
-
-			ob_start();
-			$this->render_preview_content( $totals, $trends );
-			$html = ob_get_clean();
-
-			wp_send_json_success( array( 'html' => $html ) );
-		} catch ( \Exception $e ) {
-			wp_send_json_error(
-				array(
-					'message' => $e->getMessage(),
-					'file'    => $e->getFile(),
-					'line'    => $e->getLine(),
-					'trace'   => $e->getTraceAsString(),
-				)
-			);
-		}
-	}
-
-	/**
-	 * AJAX handler for previewing the last frozen digest.
-	 *
-	 * Renders the summary of the most recently frozen/emailed report.
-	 *
-	 * @return void
-	 */
-	public function ajax_preview_last_digest(): void {
-		check_ajax_referer( 'sybgo_widget_nonce', 'nonce' );
-
-		if ( ! current_user_can( 'read' ) ) {
-			wp_send_json_error( array( 'message' => 'Unauthorized' ) );
-		}
-
-		$last_report = $this->report_repo->get_last_frozen();
-
-		if ( ! $last_report ) {
-			wp_send_json_error( array( 'message' => __( 'No previous digest available yet.', 'sybgo' ) ) );
-		}
-
-		$summary = ! empty( $last_report['summary_data'] ) ? json_decode( $last_report['summary_data'], true ) : null;
-
-		if ( ! $summary ) {
-			wp_send_json_error( array( 'message' => __( 'No summary data available for the previous digest.', 'sybgo' ) ) );
-		}
-
-		$totals = $summary['totals'];
-		$trends = $summary['trends'] ?? array();
-
-		ob_start();
-		$this->render_preview_content( $totals, $trends );
-		$html = ob_get_clean();
-
-		wp_send_json_success( array( 'html' => $html ) );
-	}
-
-	/**
-	 * Render preview content.
-	 *
-	 * @param array<string, int>                  $totals Event totals.
-	 * @param array<string, array<string, mixed>> $trends Trend data.
-	 * @return void
-	 */
-	private function render_preview_content( array $totals, array $trends ): void {
-		?>
-		<div class="sybgo-preview">
-			<h3><?php esc_html_e( 'Activity Summary', 'sybgo' ); ?></h3>
-
-			<div class="sybgo-preview-stats">
-				<?php foreach ( $totals as $type => $count ) : ?>
-					<?php
-					$trend      = $trends[ $type ] ?? null;
-					$arrow      = '';
-					$trend_text = '';
-
-					if ( $trend ) {
-						if ( 'up' === $trend['direction'] ) {
-							$arrow      = '↑';
-							$trend_text = sprintf( '+%d%%', absint( $trend['change_percent'] ) );
-						} elseif ( 'down' === $trend['direction'] ) {
-							$arrow      = '↓';
-							$trend_text = sprintf( '-%d%%', absint( $trend['change_percent'] ) );
-						}
-					}
-					?>
-					<div class="sybgo-stat-item">
-						<div class="sybgo-stat-label"><?php echo esc_html( ucwords( str_replace( '_', ' ', $type ) ) ); ?></div>
-						<div class="sybgo-stat-value">
-							<?php echo esc_html( (string) $count ); ?>
-							<?php if ( $arrow ) : ?>
-								<span class="sybgo-trend <?php echo esc_attr( $trend['direction'] ); ?>">
-									<?php echo esc_html( $arrow . ' ' . $trend_text ); ?>
-								</span>
-							<?php endif; ?>
-						</div>
-					</div>
-				<?php endforeach; ?>
-			</div>
-
-			<p class="sybgo-preview-note">
-				<?php esc_html_e( 'This is a preview of the digest that will be sent on Monday.', 'sybgo' ); ?>
-			</p>
-		</div>
-		<?php
 	}
 
 	/**

--- a/wp-plugin/assets/js/admin.js
+++ b/wp-plugin/assets/js/admin.js
@@ -20,17 +20,8 @@
 			// Filter buttons
 			$(document).on('click', '.sybgo-filters .sybgo-filter-btn', this.handleFilterClick);
 
-			// Preview button (this week)
-			$(document).on('click', '.sybgo-preview-btn', this.handlePreviewClick);
-
-			// View Previous Digest button
-			$(document).on('click', '.sybgo-preview-last-btn', this.handlePreviewLastClick);
-
 			// AI Summary button
 			$(document).on('click', '.sybgo-widget-ai-btn', this.handleAISummaryClick);
-
-			// Modal close
-			$(document).on('click', '.sybgo-modal-close, .sybgo-modal-overlay', this.handleModalClose);
 		},
 
 		handleFilterClick: function(e) {
@@ -72,45 +63,6 @@
 			});
 		},
 
-		handlePreviewClick: function(e) {
-			e.preventDefault();
-
-			$.ajax({
-				url: sybgoWidget.ajaxUrl,
-				type: 'POST',
-				data: {
-					action: 'sybgo_preview_digest',
-					nonce: sybgoWidget.nonce
-				},
-				success: function(response) {
-					if (response.success) {
-						SybgoDashboard.showModal(response.data.html);
-					}
-				}
-			});
-		},
-
-		handlePreviewLastClick: function(e) {
-			e.preventDefault();
-
-			$.ajax({
-				url: sybgoWidget.ajaxUrl,
-				type: 'POST',
-				data: {
-					action: 'sybgo_preview_last_digest',
-					nonce: sybgoWidget.nonce
-				},
-				success: function(response) {
-					if (response.success) {
-						SybgoDashboard.showModal(response.data.html);
-					} else {
-						// eslint-disable-next-line no-alert
-						alert(response.data && response.data.message ? response.data.message : 'No previous digest available.');
-					}
-				}
-			});
-		},
-
 		handleAISummaryClick: function(e) {
 			e.preventDefault();
 			var $btn = $(this);
@@ -137,23 +89,6 @@
 					$btn.prop('disabled', false);
 				}
 			});
-		},
-
-		showModal: function(content) {
-			const $modal = $('<div class="sybgo-modal-overlay active">' +
-				'<div class="sybgo-modal-content">' +
-				'<span class="sybgo-modal-close">&times;</span>' +
-				content +
-				'</div>' +
-				'</div>');
-
-			$('body').append($modal);
-		},
-
-		handleModalClose: function(e) {
-			if ($(e.target).hasClass('sybgo-modal-overlay') || $(e.target).hasClass('sybgo-modal-close')) {
-				$('.sybgo-modal-overlay').remove();
-			}
 		}
 	};
 

--- a/wp-plugin/docs/ajax-actions.md
+++ b/wp-plugin/docs/ajax-actions.md
@@ -51,20 +51,6 @@ Registered in `Dashboard_Widget::init()` and handled by `Dashboard_Widget::ajax_
 
 The handler fetches unassigned events (`report_id IS NULL`), calls `Report_Generator::generate_live_summary()` to compute totals and trends for the current week, then passes those to `AI_Summarizer::generate_summary()`. If an active report exists, the full summary object (stats + AI text) is persisted to it via `Report_Repository::save_summary_data()`, so the result survives a page reload and is visible on the active report's detail page.
 
-## sybgo_preview_digest
-
-Returns the rendered HTML for the dashboard widget's digest preview modal.
-
-Registered in `Dashboard_Widget::init()` and handled by `Dashboard_Widget::ajax_preview_digest()`.
-
-| Parameter | Source | Description |
-|-----------|--------|-------------|
-| `nonce` | `$_POST` | Nonce verified against `sybgo_widget_nonce` |
-
-**Capability required:** `manage_options`
-
-Returns an HTML fragment rendered by `Dashboard_Widget::render_preview_content()`. No AI summary is included in the preview.
-
 ## sybgo_filter_events
 
 Returns filtered event rows for the dashboard widget's event list.

--- a/wp-plugin/docs/development.md
+++ b/wp-plugin/docs/development.md
@@ -335,17 +335,14 @@ sybgo/
 
 ## Admin AJAX Actions
 
-The dashboard widget registers three AJAX actions, all protected by the `sybgo_widget_nonce` nonce (key: `nonce` in the POST body). All three require the `read` capability.
+The dashboard widget registers two AJAX actions, both protected by the `sybgo_widget_nonce` nonce (key: `nonce` in the POST body).
 
-| Action | Handler | Success response | Error response |
-|--------|---------|-----------------|----------------|
-| `sybgo_filter_events` | `Dashboard_Widget::ajax_filter_events()` | `{html: string, count: int}` | — |
-| `sybgo_preview_digest` | `Dashboard_Widget::ajax_preview_digest()` | `{html: string}` | `{message, file, line, trace}` |
-| `sybgo_preview_last_digest` | `Dashboard_Widget::ajax_preview_last_digest()` | `{html: string}` | `{message: string}` |
+| Action | Handler | Capability | Success response |
+|--------|---------|------------|-----------------|
+| `sybgo_filter_events` | `Dashboard_Widget::ajax_filter_events()` | `read` | `{html: string, count: int}` |
+| `sybgo_widget_ai_summary` | `Dashboard_Widget::ajax_widget_ai_summary()` | `manage_options` | `{summary: string}` |
 
-`sybgo_preview_last_digest` fetches the most recently frozen report via `Report_Repository::get_last_frozen()`, reads its `summary_data` JSON (fields: `totals`, `trends`, `ai_summary`), and renders the same preview modal used by `sybgo_preview_digest`. It returns an error if no frozen report exists or if `summary_data` is absent.
-
-The nonce value and `ajaxUrl` are available in the `sybgoWidget` JS object (localized by `Dashboard_Widget::enqueue_assets()`).
+The nonce value and `ajaxUrl` are available in the `sybgoWidget` JS object (localized by `Dashboard_Widget::enqueue_assets()`). See [ajax-actions.md](ajax-actions.md) for full parameter and response documentation.
 
 ## Admin Classes: Constructor Dependencies
 


### PR DESCRIPTION
# Description

The dashboard widget had two buttons — \"Preview This Week's Digest\" and \"View Previous Digest\" — that opened modal popups showing the same data already available on the Reports admin detail pages. This removes the duplicate UI path and its supporting code.

Closes #49

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #49

## Detailed scenario

### What was tested

**Manual test — links render correctly:**
1. Activated the plugin on a local WordPress install with at least one active report and one frozen report in the database.
2. Navigated to WP Admin → Dashboard.
3. Located the "Site Activity Digest" widget — confirmed it shows a "View This Week's Details" link and a "View Last Week's Details" link instead of the former buttons.
4. Clicked each link — confirmed they navigate to the correct report detail page (`admin.php?page=sybgo-reports&view=details&report_id=<id>`).

**Manual test — graceful absence:**
1. On a fresh install with no reports, the widget actions area rendered empty — no broken links or JS errors.

**Manual test — no modal regression:**
1. Confirmed no modal overlay appears anywhere on the dashboard page after the change.
2. Checked browser console — no JS errors related to `sybgo_preview_digest` or `sybgo_preview_last_digest`.

### How to test

1. Install and activate the plugin on a WordPress instance.
2. Generate some events (publish a post, create a user, etc.).
3. Trigger a weekly freeze to create a frozen report: `wp cron event run sybgo_freeze_weekly_report`
4. Navigate to WP Admin → Dashboard.
5. In the "Site Activity Digest" widget, verify:
   - No "Preview This Week's Digest" or "View Previous Digest" buttons are present.
   - A "View This Week's Details" link is visible (pointing to the active report).
   - A "View Last Week's Details" link is visible (pointing to the frozen report).
6. Click each link and verify it opens the correct report detail page.
7. Open browser DevTools → Network tab and confirm no AJAX requests to `sybgo_preview_digest` or `sybgo_preview_last_digest` are fired.
8. On a fresh install with no reports, verify the widget renders without links and without errors.

### Affected Features & Quality Assurance Scope

- Dashboard widget (WP Admin → Dashboard → Site Activity Digest widget)
- No impact on the Reports admin page, email sending, event tracking, or AI summary features

## Technical description

### Documentation

Removed from `Dashboard_Widget`:
- `ajax_preview_digest()` and its `wp_ajax_sybgo_preview_digest` registration
- `ajax_preview_last_digest()` and its `wp_ajax_sybgo_preview_last_digest` registration
- `render_preview_content()` helper (only used by the two removed handlers)
- The inline `#sybgo-preview-modal` HTML block

`render_widget()` now calls `Report_Repository::get_active()` and `Report_Repository::get_last_frozen()` and outputs `<a>` links to `admin.php?page=sybgo-reports&view=details&report_id=<id>`. Each link is rendered only when the corresponding report exists.

From `assets/js/admin.js`, removed: `handlePreviewClick`, `handlePreviewLastClick`, `showModal`, `handleModalClose`, and their `$(document).on(...)` bindings.

Updated docs: [wp-plugin/docs/ajax-actions.md](wp-plugin/docs/ajax-actions.md), [wp-plugin/docs/development.md](wp-plugin/docs/development.md).

### New dependencies

None.

### Risks

None identified. The removed AJAX actions were internal to the widget and not part of any public extension API. The replacement links are standard WordPress admin URLs that already exist (guarded by `#41` having been merged).

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all items are applicable and checked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

## Unticked additional checks justification

- Observability: no new code paths introduced; the links are static HTML rendered server-side.
- Error handling: the only failure mode (missing report) is handled by conditional rendering — no exception-throwing code paths were added.