### PR TITLE
fix(email): cast report id to int when sending weekly digest (#68)

### DIFF
--- a/wp-plugin/Tests/Unit/SybgoCronCallbacksTest.php
+++ b/wp-plugin/Tests/Unit/SybgoCronCallbacksTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Sybgo Cron Callbacks Unit Tests
+ *
+ * Regression tests for the cron callbacks exposed by the Sybgo singleton.
+ *
+ * @package Sybgo\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit;
+
+use Brain\Monkey;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Sybgo\Database\Report_Repository;
+use Sybgo\Email\Email_Manager;
+use Sybgo\Factory;
+use Sybgo\Sybgo;
+
+/**
+ * Regression tests for cron callbacks on the main plugin class.
+ */
+class SybgoCronCallbacksTest extends TestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down test environment.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Regression test for #68.
+	 *
+	 * `Email_Manager::send_report_email()` declares `int $report_id` under
+	 * `declare(strict_types=1)`. The repository returns rows from $wpdb where
+	 * the `id` column comes back as a string. Without an explicit cast in the
+	 * cron callback, the strict-typed call fataled.
+	 *
+	 * This test pins the callback contract: when the report repository hands
+	 * back a string id (as $wpdb does), the email manager must receive an int.
+	 *
+	 * @return void
+	 */
+	public function test_send_report_emails_callback_casts_string_id_to_int(): void {
+		$report_repo   = Mockery::mock( Report_Repository::class );
+		$email_manager = Mockery::mock( Email_Manager::class );
+
+		// Simulate the $wpdb behavior: numeric column returned as string.
+		$report_repo->shouldReceive( 'get_last_frozen' )
+			->once()
+			->andReturn( array( 'id' => '42' ) );
+
+		// The fix: callback must pass an int, never a string.
+		$email_manager->shouldReceive( 'send_report_email' )
+			->once()
+			->with( Mockery::on(
+				static function ( $arg ): bool {
+					return is_int( $arg ) && 42 === $arg;
+				}
+			) )
+			->andReturn( true );
+
+		$factory = Mockery::mock( Factory::class );
+		$factory->shouldReceive( 'create_report_repository' )->andReturn( $report_repo );
+		$factory->shouldReceive( 'create_email_manager' )->andReturn( $email_manager );
+
+		$sybgo = $this->build_sybgo_with_factory( $factory );
+
+		// Should not raise a TypeError.
+		$sybgo->send_report_emails_callback();
+
+		// If we got here, the cast is in place.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Regression test for #68 — early return path.
+	 *
+	 * When there is no frozen report, the callback must not call the email
+	 * manager (and must not fatal).
+	 *
+	 * @return void
+	 */
+	public function test_send_report_emails_callback_noops_when_no_frozen_report(): void {
+		$report_repo   = Mockery::mock( Report_Repository::class );
+		$email_manager = Mockery::mock( Email_Manager::class );
+
+		$report_repo->shouldReceive( 'get_last_frozen' )
+			->once()
+			->andReturn( null );
+
+		$email_manager->shouldNotReceive( 'send_report_email' );
+
+		$factory = Mockery::mock( Factory::class );
+		$factory->shouldReceive( 'create_report_repository' )->andReturn( $report_repo );
+		$factory->shouldReceive( 'create_email_manager' )->andReturn( $email_manager );
+
+		$sybgo = $this->build_sybgo_with_factory( $factory );
+		$sybgo->send_report_emails_callback();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Build a Sybgo instance bypassing the singleton & private constructor,
+	 * with the Factory replaced by a mock.
+	 *
+	 * @param Factory $factory Factory mock.
+	 * @return Sybgo
+	 */
+	private function build_sybgo_with_factory( Factory $factory ): Sybgo {
+		$reflection = new ReflectionClass( Sybgo::class );
+		$instance   = $reflection->newInstanceWithoutConstructor();
+
+		$factory_prop = $reflection->getProperty( 'factory' );
+		$factory_prop->setAccessible( true );
+		$factory_prop->setValue( $instance, $factory );
+
+		return $instance;
+	}
+}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -441,14 +441,18 @@ class Sybgo {
 			return;
 		}
 
+		// Cast report id to int — $wpdb returns column values as strings, but
+		// Email_Manager::send_report_email() is strictly typed against int.
+		$report_id = (int) $last_frozen['id'];
+
 		// Send email.
-		$sent = $email_manager->send_report_email( $last_frozen['id'] );
+		$sent = $email_manager->send_report_email( $report_id );
 
 		// Log result.
 		if ( $sent ) {
-			Logger::info( sprintf( 'Successfully sent weekly digest for report #%d', $last_frozen['id'] ) );
+			Logger::info( sprintf( 'Successfully sent weekly digest for report #%d', $report_id ) );
 		} else {
-			Logger::error( sprintf( 'Failed to send weekly digest for report #%d', $last_frozen['id'] ) );
+			Logger::error( sprintf( 'Failed to send weekly digest for report #%d', $report_id ) );
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes:
- Closes #68

The weekly digest cron (`sybgo_send_report_emails`) fataled end-to-end on a live WP install because `Email_Manager::send_report_email()` declares `int $report_id` under `declare(strict_types=1)`, but `$wpdb->get_last_frozen()` returns the `id` column as a string (standard `$wpdb` behavior). Users with the digest enabled never received any emails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated: New PHPUnit regression test `SybgoCronCallbacksTest::test_send_report_emails_callback_casts_string_id_to_int` simulates the `$wpdb` behavior (id returned as string `'42'`) and asserts the email manager receives a true `int`. Verified test fails without the fix (TypeError) and passes with it.

Manual: Reproduced the fatal on wp-env (WP 6.9.4, PHP 8.2):
1. `wp cron event run sybgo_freeze_weekly_report` → frozen report created
2. `wp cron event run sybgo_send_report_emails` → fatal `TypeError: ... must be of type int, string given` pre-fix
3. After applying the fix locally to wp-env, the same sequence completes successfully (the lingering wpdb::prepare notice is tracked separately as #70).

### How to test

1. Boot wp-env (`bin/dev-up.sh`) and seed (`bin/dev-seed.sh`).
2. `npx @wordpress/env run cli wp cron event run sybgo_freeze_weekly_report`
3. `npx @wordpress/env run cli wp cron event run sybgo_send_report_emails`
4. Expect no fatal. Verify `wp-content/debug.log` for any remaining issues.
5. Run `composer test-unit` in `wp-plugin/` — 40 tests should pass (38 existing + 2 new).

### Affected Features & Quality Assurance Scope

Weekly report email digest path (`sybgo_send_report_emails` cron). Same call site is also used in `class-sybgo.php` only; admin "Resend" flow already passes an int via `absint()`.

## Technical description

### Documentation

`Email_Manager::send_report_email()` lives in the lib and is strictly typed (`int $report_id`). The plugin-side cron callback reads the report id from a `$wpdb` row and was passing it through unchanged. WordPress's `$wpdb` returns column values as strings regardless of column type — this is documented behavior. The minimal, surgical fix is a single cast at the call site:

```php
$report_id = (int) $last_frozen['id'];
$sent      = $email_manager->send_report_email( $report_id );
```

This keeps the strict-typed signature in the lib (the right contract) and corrects only the offending boundary.

### New dependencies

None.

### Risks

Very narrow scope (one call site, one cast). Regression test pins the contract so future refactors cannot silently re-introduce the bug.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all items relevant and addressed.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)