### PR TITLE
fix(reports): drop bogus wpdb::prepare in get_last_frozen (#70)

### DIFF
--- a/lib/Tests/Unit/Database/ReportRepositoryTest.php
+++ b/lib/Tests/Unit/Database/ReportRepositoryTest.php
@@ -109,6 +109,62 @@ class ReportRepositoryTest extends TestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// get_last_frozen()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Regression test for #70.
+	 *
+	 * get_last_frozen() used to wrap a placeholder-free query in $wpdb->prepare()
+	 * with a bogus empty-string arg. That triggered two `wpdb::prepare was called
+	 * incorrectly` notices on every cron run. The fix removes the prepare() call
+	 * (the query is fully static and has no user input).
+	 *
+	 * This test pins the contract: prepare() must NEVER be called for the
+	 * static get_last_frozen() query.
+	 */
+	public function test_get_last_frozen_does_not_call_prepare_for_static_query(): void {
+		$report = array(
+			'id'         => 1,
+			'status'     => 'frozen',
+			'frozen_at'  => '2026-03-01 00:00:00',
+		);
+
+		// The critical assertion: prepare() must NOT be invoked.
+		$this->wpdb->shouldNotReceive( 'prepare' );
+
+		$this->wpdb->shouldReceive( 'get_row' )
+			->once()
+			->with(
+				Mockery::pattern( "/SELECT \* FROM wp_sybgo_reports WHERE status IN \('frozen', 'emailed'\)/" ),
+				'ARRAY_A'
+			)
+			->andReturn( $report );
+
+		$result = $this->report_repo->get_last_frozen();
+
+		$this->assertSame( $report, $result );
+	}
+
+	/**
+	 * Regression test for #70 (no-result path).
+	 *
+	 * When no frozen report exists, get_last_frozen() still must not call
+	 * prepare() and must return null.
+	 */
+	public function test_get_last_frozen_returns_null_without_calling_prepare(): void {
+		$this->wpdb->shouldNotReceive( 'prepare' );
+
+		$this->wpdb->shouldReceive( 'get_row' )
+			->once()
+			->andReturn( null );
+
+		$result = $this->report_repo->get_last_frozen();
+
+		$this->assertNull( $result );
+	}
+
+	// -------------------------------------------------------------------------
 	// set_ai_summary()
 	// -------------------------------------------------------------------------
 

--- a/lib/database/class-report-repository.php
+++ b/lib/database/class-report-repository.php
@@ -150,12 +150,11 @@ class Report_Repository {
 
 		global $wpdb;
 
+		// No user input in the query — wpdb::prepare() would warn (no placeholders).
+		// Table name is a trusted internal property; statuses are literals.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Internal table name; no user input.
 		$report = $wpdb->get_row(
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- No user input; prepare used for consistency.
-				"SELECT * FROM {$this->table} WHERE status IN ('frozen', 'emailed') ORDER BY frozen_at DESC LIMIT 1",
-				''
-			),
+			"SELECT * FROM {$this->table} WHERE status IN ('frozen', 'emailed') ORDER BY frozen_at DESC LIMIT 1",
 			ARRAY_A
 		);
 


### PR DESCRIPTION
# Description

Fixes:
- Closes #70

`Report_Repository::get_last_frozen()` wrapped a fully static query in `$wpdb->prepare()` and passed an empty-string as a placeholder value. The query string contains zero placeholders, so WordPress fires two `wpdb::prepare was called incorrectly` notices on every cron run (and on any other code path that hits this method). The query result was unaffected, but the notice clutters `debug.log` and trips WordPress.org reviewers and any production site with `WP_DEBUG=true`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated: New PHPUnit regression tests `ReportRepositoryTest::test_get_last_frozen_does_not_call_prepare_for_static_query` and `test_get_last_frozen_returns_null_without_calling_prepare` use Mockery `shouldNotReceive('prepare')` to pin the contract. Verified both fail without the fix and pass with it.

Manual: Reproduced on wp-env (WP 6.9.4):
1. Ran `wp cron event run sybgo_freeze_weekly_report` then `wp cron event run sybgo_send_report_emails`.
2. Pre-fix: `debug.log` contains the two notices.
3. Post-fix: `grep -E 'prepare|Notice|Fatal|TypeError' debug.log` returns no matches.

### How to test

1. Boot wp-env (`bin/dev-up.sh`) and seed (`bin/dev-seed.sh`).
2. Truncate `wp-content/debug.log`.
3. `npx @wordpress/env run cli wp cron event run sybgo_freeze_weekly_report`
4. `npx @wordpress/env run cli wp cron event run sybgo_send_report_emails`
5. `npx @wordpress/env run cli bash -c "grep prepare /var/www/html/wp-content/debug.log"` — expect no output.
6. Run `composer test-unit` in `lib/` — 152 tests should pass (150 existing + 2 new).

Note: To fully exercise the cron path end-to-end, this branch should be tested on top of #72 (fix for #68) since the send-emails cron fataled pre-fix on a separate type bug. Each PR is independently mergeable; they fix two distinct issues.

### Affected Features & Quality Assurance Scope

`Report_Repository::get_last_frozen()` — read path for the most recent frozen report. Used by the weekly digest cron and (potentially) by admin code that surfaces the last digest.

## Technical description

### Documentation

The original code looked like:

```php
$wpdb->get_row(
    $wpdb->prepare(
        "SELECT * FROM {$this->table} WHERE status IN ('frozen', 'emailed') ORDER BY frozen_at DESC LIMIT 1",
        ''
    ),
    ARRAY_A
);
```

There are no `%s`/`%d` tokens in the SQL — `prepare()` has nothing to do, and WordPress treats this as a misuse. The query also has no user input (table name is internal, statuses are literals), so `prepare()` was never needed. The fix calls `get_row()` directly with the static SQL, with the appropriate phpcs ignore for the interpolated table name.

### New dependencies

None.

### Risks

Minimal — the query is unchanged; only the (no-op) `prepare()` wrapper is removed. The new phpcs ignore is scoped narrowly and justified inline.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all items relevant and addressed.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)