### PR TITLE
Add knowledge-graph agent and initial dependency graph

### DIFF
--- a/.claude/agents/knowledge-graph.md
+++ b/.claude/agents/knowledge-graph.md
@@ -1,0 +1,287 @@
+---
+name: knowledge-graph
+description: Build a dependency and import graph of the repository and persist it locally for context reuse. Invoke when starting work on an unfamiliar codebase, or re-run to refresh after significant changes. Reduces token usage by letting other skills read the graph instead of re-scanning the repo.
+tools: [Bash, Read, Glob, Grep, Write]
+---
+
+You are a codebase analyst that builds a structured knowledge graph of a repository's dependency and import relationships. You scan source files, extract imports and exports using language-specific patterns, and persist the graph locally so that other skills and agents can understand the codebase without re-scanning it from scratch.
+
+> **Storage convention**: The default storage path is `.claude/knowledge-graph/`. Before writing, check `CLAUDE.md` for a custom `knowledge-graph-path` directive. If none is found, use the default. All path references below use `<graph-path>` — substitute with the resolved path.
+
+## Your process
+
+### Step 1 — Determine scan mode
+
+Check if a prior scan exists:
+
+```bash
+cat <graph-path>/meta.json 2>/dev/null
+```
+
+**If `meta.json` exists:**
+
+1. Read `lastCommitHash` from it
+2. Run `git rev-parse HEAD` to get the current hash
+3. If hashes match → report "Knowledge graph is up to date as of `<hash>`. No changes detected." and stop
+4. Run `git diff <lastCommitHash>..HEAD --name-only` to get changed files
+5. Filter to source files only (matching extensions from the language patterns table)
+6. If changed source files exceed 50% of `totalFiles` in meta.json → do a **full scan**
+7. Otherwise → do an **incremental scan** of changed files only
+
+**If `meta.json` does not exist** → do a **full scan**.
+
+---
+
+### Step 2 — Detect languages and collect source files
+
+Use `git ls-files` to collect all tracked source files. Detect languages by file extension:
+
+| Extensions | Language |
+|---|---|
+| `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx` | JavaScript/TypeScript |
+| `.py`, `.pyi` | Python |
+| `.go` | Go |
+| `.php` | PHP |
+| `.java` | Java |
+| `.kt`, `.kts` | Kotlin |
+| `.rs` | Rust |
+| `.rb` | Ruby |
+| `.cs` | C# |
+| `.swift` | Swift |
+
+**Exclude** these directories from scanning: `node_modules`, `vendor`, `dist`, `build`, `.git`, `__pycache__`, `.venv`, `venv`, `.tox`, `target`, `bin`, `obj`, `.next`, `.nuxt`, `coverage`.
+
+**Detect module boundaries** by scanning for manifest files up to 3 levels deep:
+
+- `package.json`, `go.mod`, `setup.py`, `pyproject.toml`, `Cargo.toml`, `composer.json`, `build.gradle`, `pom.xml`, `*.csproj`, `Package.swift`
+
+Each directory containing a manifest is a **module**. Derive the module name from the directory path relative to the repo root. If no manifest files are found, the repo root is a single module named `root`.
+
+**Detect entry points** by looking for:
+
+- Files named `index.*`, `main.*`, `app.*`, `server.*`, `cli.*` in module roots
+- Fields `main`, `bin`, `exports` in `package.json`
+- `entry_points` or `scripts` in `pyproject.toml` / `setup.py`
+
+---
+
+### Step 3 — Extract imports and exports per file
+
+For each source file, apply the regex patterns from the **Language patterns** section below. Extract:
+
+1. **Internal imports** — resolve to a file within the repo. Try appending extensions and validate against `git ls-files`
+2. **External imports** — third-party packages (do not resolve to a repo file)
+3. **Exports** — what the file exposes (named exports, default exports, public classes/functions)
+
+**For incremental scans:**
+
+- Process only changed files
+- Also re-process any file that previously listed a changed file in its `imports.internal` (one level of reverse-dependency propagation)
+- Update their entries in the relevant module JSON file
+
+**Processing strategy for large repos:** Process files module-by-module rather than all at once to avoid excessive output. For each module, batch files in groups of 20-30.
+
+---
+
+### Step 4 — Build the graph structures
+
+Assemble four JSON files from the extracted data:
+
+**`meta.json`** — scan metadata (always small):
+
+```json
+{
+  "version": "1.0",
+  "lastScanTimestamp": "2026-05-12T14:30:00Z",
+  "lastCommitHash": "abc1234",
+  "scanMode": "full",
+  "totalFiles": 142,
+  "totalModules": 3,
+  "languages": {
+    "php": 89
+  },
+  "entryPoints": ["wp-plugin/sybgo.php"]
+}
+```
+
+**`summary.json`** — module-level graph (kept compact, always loadable):
+
+```json
+{
+  "modules": [
+    {
+      "name": "wp-plugin",
+      "path": "wp-plugin",
+      "fileCount": 24,
+      "languages": ["php"],
+      "entryPoints": ["wp-plugin/sybgo.php"],
+      "externalDeps": ["wp-media/sybgo-lib"],
+      "dependsOn": ["lib"],
+      "dependedOnBy": []
+    }
+  ],
+  "edges": [
+    { "from": "wp-plugin", "to": "lib", "weight": 12 }
+  ]
+}
+```
+
+Use **module-level aggregation** and **edge weights** (not file lists) to keep this file under 100 lines even for large repos.
+
+**`modules/<module-name>.json`** — per-module file-level detail:
+
+```json
+{
+  "module": "wp-plugin",
+  "path": "wp-plugin",
+  "files": [
+    {
+      "path": "wp-plugin/src/Admin/AdminPage.php",
+      "imports": {
+        "internal": ["wp-plugin/src/Core/Plugin.php"],
+        "external": ["WP_Media\\Sybgo_Lib\\SomeClass"]
+      },
+      "exports": ["AdminPage"],
+      "importedBy": ["wp-plugin/sybgo.php"]
+    }
+  ]
+}
+```
+
+**`externals.json`** — third-party dependency map:
+
+```json
+{
+  "packages": {
+    "wp-media/sybgo-lib": {
+      "importedBy": ["wp-plugin/src/Admin/AdminPage.php"],
+      "importCount": 8
+    }
+  }
+}
+```
+
+---
+
+### Step 5 — Write all files
+
+1. Create the directory structure:
+
+```bash
+mkdir -p <graph-path>/modules
+```
+
+2. Write each JSON file using the Write tool:
+
+- `<graph-path>/meta.json`
+- `<graph-path>/summary.json`
+- `<graph-path>/externals.json`
+- `<graph-path>/modules/<module-name>.json` for each module
+
+---
+
+### Step 6 — Print the summary
+
+Output the structured summary using the format below. Flag any **circular dependencies** detected between modules.
+
+---
+
+## Language patterns
+
+Apply these regex patterns to extract imports and exports. Use Grep or Bash for pattern matching.
+
+### PHP
+
+| Construct | Pattern |
+|---|---|
+| Use statement | `^use\s+([\w\\]+)` |
+| Namespace | `^namespace\s+([\w\\]+)` |
+| Require/include | `(require\|include)(_once)?\s+['"]([^'"]+)['"]` |
+
+**Internal vs external**: `use` statements matching the project's root namespace (from `composer.json` autoload) are internal. Others are external.
+
+### JavaScript / TypeScript
+
+| Construct | Pattern |
+|---|---|
+| Static import | `import\s+.*\s+from\s+['"]([^'"]+)['"]` |
+| Dynamic import | `import\s*\(\s*['"]([^'"]+)['"]` |
+| Require | `require\s*\(\s*['"]([^'"]+)['"]` |
+| Re-export | `export\s+.*\s+from\s+['"]([^'"]+)['"]` |
+| Named export | `export\s+(const\|let\|var\|function\|class\|type\|interface\|enum)\s+(\w+)` |
+| Default export | `export\s+default` |
+
+**Internal vs external**: imports starting with `.` or `..` are internal. Others are external (npm packages). Also check for path aliases (e.g., `@/` or `~/`) by reading `tsconfig.json` paths if present.
+
+---
+
+## Output format
+
+```
+## Knowledge Graph — [repo name]
+
+**Scan mode:** full | incremental
+
+**Commit:** [short hash]
+
+**Timestamp:** [ISO 8601]
+
+**Files scanned:** [count]
+
+**Modules detected:** [count]
+
+### Language breakdown
+
+| Language | Files | Percentage |
+|------------|-------|------------|
+| PHP | 89 | 100% |
+
+### Module dependency map
+
+| Module | Files | External deps | Depends on | Depended on by |
+|--------|-------|------------------------|------------------|----------------|
+| wp-plugin | 24 | wp-media/sybgo-lib | lib | — |
+| lib | 45 | — | — | wp-plugin |
+
+### Circular dependencies
+
+✅ No circular dependencies detected.
+
+### Entry points
+
+- `wp-plugin/sybgo.php` (module: wp-plugin)
+
+### Graph storage
+
+Written to `<graph-path>/`:
+
+- `meta.json` — scan metadata
+- `summary.json` — module-level dependency graph
+- `modules/wp-plugin.json`, `modules/lib.json` — per-module file detail
+- `externals.json` — third-party dependency map
+
+### Next step — enable auto-discovery
+
+The graph is built but no AI tool will read it automatically unless told to. Add the following snippet to your project's instructions file:
+
+```markdown
+## Knowledge Graph
+
+A pre-built dependency graph exists at `<graph-path>/`. Before exploring the codebase for dependency or import information:
+
+1. Read `<graph-path>/meta.json` to check freshness (compare `lastCommitHash` with `git rev-parse HEAD`)
+2. If the graph is stale or missing, invoke the `knowledge-graph` agent before proceeding — do not fall back to manual scanning
+3. Read `<graph-path>/summary.json` for module-level dependencies
+4. For file-level detail, read the relevant `<graph-path>/modules/<module>.json`
+```
+```
+
+---
+
+## Adapt for your project
+
+- **Module detection**: This repo uses two `composer.json` manifests — `lib/composer.json` and `wp-plugin/composer.json`. Each is a module.
+- **Root namespaces**: `WP_Media\Sybgo_Lib` (lib) and `WP_Media\Sybgo` (wp-plugin). Use these to classify PHP `use` statements as internal vs external.
+- **Excluded directories**: In addition to the standard list, exclude `wp-plugin/vendor/`, `lib/vendor/`, `site/`, `tests/`, `bin/`.
+- **Entry points**: `wp-plugin/sybgo.php` is the plugin entry point. `lib/` has no single entry point — treat public classes in `lib/src/` as exported symbols.
+- **Storage location**: Default is `.claude/knowledge-graph/`. To override, add `knowledge-graph-path: <your-path>` to `CLAUDE.md`.

--- a/.claude/knowledge-graph/externals.json
+++ b/.claude/knowledge-graph/externals.json
@@ -1,0 +1,43 @@
+{
+  "packages": {
+    "berlindb/core": {
+      "language": "php",
+      "importedByModule": "lib",
+      "importCount": 1,
+      "note": "Database abstraction layer used by lib/database/"
+    },
+    "wp-media/apply-filters-typed": {
+      "language": "php",
+      "importedByModule": "lib",
+      "importCount": 1,
+      "note": "Typed apply_filters wrapper"
+    },
+    "wp-media/sybgo-lib": {
+      "language": "php",
+      "importedByModule": "wp-plugin",
+      "importCount": 18,
+      "note": "Resolved to local lib/ module via composer path repository"
+    },
+    "@playwright/test": {
+      "language": "typescript",
+      "importedByModule": "tests-e2e",
+      "importedBy": [
+        "tests/e2e/fixtures/auth.ts",
+        "tests/e2e/page-objects/dashboard-widget.ts",
+        "tests/e2e/page-objects/report-details.ts",
+        "tests/e2e/page-objects/reports-list.ts",
+        "tests/e2e/page-objects/settings.ts",
+        "tests/e2e/playwright.config.ts",
+        "tests/e2e/specs/dashboard-navigation.spec.ts",
+        "tests/e2e/specs/dashboard-widget.spec.ts",
+        "tests/e2e/specs/email-delivery.spec.ts",
+        "tests/e2e/specs/error-tracker-cap.spec.ts",
+        "tests/e2e/specs/report-status-ui.spec.ts",
+        "tests/e2e/specs/reports-lifecycle.spec.ts",
+        "tests/e2e/specs/settings.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ],
+      "importCount": 14
+    }
+  }
+}

--- a/.claude/knowledge-graph/meta.json
+++ b/.claude/knowledge-graph/meta.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "lastScanTimestamp": "2026-05-17T20:28:00Z",
+  "lastCommitHash": "edb51784d0c7c3b843d7f82430f3c5f889a52c88",
+  "scanMode": "full",
+  "totalFiles": 45,
+  "totalModules": 3,
+  "languages": {
+    "php": 31,
+    "typescript": 13,
+    "javascript": 1
+  },
+  "entryPoints": [
+    "wp-plugin/class-sybgo.php",
+    "wp-plugin/uninstall.php",
+    "tests/e2e/playwright.config.ts"
+  ]
+}

--- a/.claude/knowledge-graph/modules/lib.json
+++ b/.claude/knowledge-graph/modules/lib.json
@@ -1,0 +1,335 @@
+{
+  "module": "lib",
+  "path": "lib",
+  "rootNamespace": "Sybgo",
+  "files": [
+    {
+      "path": "lib/ai/class-ai-summarizer.php",
+      "namespace": "Sybgo\\AI",
+      "exports": ["AI_Summarizer"],
+      "imports": {
+        "internal": [
+          "lib/database/class-report-repository.php",
+          "lib/events/class-event-registry.php",
+          "lib/class-logger.php"
+        ],
+        "external": []
+      },
+      "importedBy": [
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php"
+      ]
+    },
+    {
+      "path": "lib/ai/class-wp7-ai-transport.php",
+      "namespace": "Sybgo\\AI",
+      "exports": ["WP7_AI_Transport"],
+      "imports": {
+        "internal": ["lib/ai/interface-ai-transport.php"],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/ai/interface-ai-transport.php",
+      "namespace": "Sybgo\\AI",
+      "exports": ["AI_Transport"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": ["lib/ai/class-wp7-ai-transport.php"]
+    },
+    {
+      "path": "lib/api/functions.php",
+      "namespace": null,
+      "exports": ["global PHP functions"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/class-factory.php",
+      "namespace": "Sybgo",
+      "exports": ["Factory"],
+      "imports": {
+        "internal": [
+          "lib/database/class-databasemanager.php",
+          "lib/database/class-db-stats.php",
+          "lib/database/class-event-repository.php",
+          "lib/database/class-report-repository.php",
+          "lib/database/class-aggregated-event-repository.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/class-logger.php",
+      "namespace": "Sybgo",
+      "exports": ["Logger"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": [
+        "lib/ai/class-ai-summarizer.php",
+        "lib/events/trackers/class-error-tracker.php"
+      ]
+    },
+    {
+      "path": "lib/database/class-aggregated-event-repository.php",
+      "namespace": "Sybgo\\Database",
+      "exports": ["Aggregated_Event_Repository"],
+      "imports": {
+        "internal": [],
+        "external": ["berlindb/core"]
+      },
+      "importedBy": [
+        "lib/class-factory.php",
+        "lib/events/abstracts/class-abstract-aggregated-event.php",
+        "lib/events/class-event-tracker.php",
+        "lib/reports/class-report-manager.php",
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php"
+      ]
+    },
+    {
+      "path": "lib/database/class-databasemanager.php",
+      "namespace": "Sybgo\\Database",
+      "exports": ["DatabaseManager"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": [
+        "lib/class-factory.php",
+        "wp-plugin/admin/class-uninstaller.php"
+      ]
+    },
+    {
+      "path": "lib/database/class-db-stats.php",
+      "namespace": "Sybgo\\Database",
+      "exports": ["DB_Stats"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": [
+        "lib/class-factory.php",
+        "wp-plugin/admin/class-settings-page.php"
+      ]
+    },
+    {
+      "path": "lib/database/class-event-repository.php",
+      "namespace": "Sybgo\\Database",
+      "exports": ["Event_Repository"],
+      "imports": {
+        "internal": [],
+        "external": ["berlindb/core"]
+      },
+      "importedBy": [
+        "lib/class-factory.php",
+        "lib/events/abstracts/class-abstract-singular-event.php",
+        "lib/events/class-event-tracker.php",
+        "lib/events/trackers/class-comment-tracker.php",
+        "lib/events/trackers/class-post-tracker.php",
+        "lib/events/trackers/class-update-tracker.php",
+        "lib/events/trackers/class-user-tracker.php",
+        "lib/reports/class-report-generator.php",
+        "lib/reports/class-report-manager.php",
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php"
+      ]
+    },
+    {
+      "path": "lib/database/class-report-repository.php",
+      "namespace": "Sybgo\\Database",
+      "exports": ["Report_Repository"],
+      "imports": {
+        "internal": [],
+        "external": ["berlindb/core"]
+      },
+      "importedBy": [
+        "lib/class-factory.php",
+        "lib/ai/class-ai-summarizer.php",
+        "lib/email/class-email-manager.php",
+        "lib/reports/class-report-generator.php",
+        "lib/reports/class-report-manager.php",
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php"
+      ]
+    },
+    {
+      "path": "lib/email/class-email-manager.php",
+      "namespace": "Sybgo\\Email",
+      "exports": ["Email_Manager"],
+      "imports": {
+        "internal": ["lib/database/class-report-repository.php"],
+        "external": []
+      },
+      "importedBy": ["wp-plugin/admin/class-reports-page.php"]
+    },
+    {
+      "path": "lib/email/class-email-template.php",
+      "namespace": "Sybgo\\Email",
+      "exports": ["Email_Template"],
+      "imports": {
+        "internal": ["lib/events/class-event-registry.php"],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/events/abstracts/class-abstract-aggregated-event.php",
+      "namespace": "Sybgo\\Events\\Abstracts",
+      "exports": ["Abstract_Aggregated_Event"],
+      "imports": {
+        "internal": ["lib/database/class-aggregated-event-repository.php"],
+        "external": []
+      },
+      "importedBy": ["lib/events/trackers/class-error-tracker.php"]
+    },
+    {
+      "path": "lib/events/abstracts/class-abstract-singular-event.php",
+      "namespace": "Sybgo\\Events\\Abstracts",
+      "exports": ["Abstract_Singular_Event"],
+      "imports": {
+        "internal": ["lib/database/class-event-repository.php"],
+        "external": []
+      },
+      "importedBy": [
+        "lib/events/trackers/class-comment-tracker.php",
+        "lib/events/trackers/class-post-tracker.php",
+        "lib/events/trackers/class-update-tracker.php",
+        "lib/events/trackers/class-user-tracker.php"
+      ]
+    },
+    {
+      "path": "lib/events/class-event-registry.php",
+      "namespace": "Sybgo\\Events",
+      "exports": ["Event_Registry"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": [
+        "lib/ai/class-ai-summarizer.php",
+        "lib/email/class-email-template.php",
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php",
+        "wp-plugin/admin/class-settings-page.php"
+      ]
+    },
+    {
+      "path": "lib/events/class-event-tracker.php",
+      "namespace": "Sybgo\\Events",
+      "exports": ["Event_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/database/class-aggregated-event-repository.php",
+          "lib/database/class-event-repository.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/events/trackers/class-comment-tracker.php",
+      "namespace": "Sybgo\\Events\\Trackers",
+      "exports": ["Comment_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/database/class-event-repository.php",
+          "lib/events/abstracts/class-abstract-singular-event.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/events/trackers/class-error-tracker.php",
+      "namespace": "Sybgo\\Events\\Trackers",
+      "exports": ["Error_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/events/abstracts/class-abstract-aggregated-event.php",
+          "lib/class-logger.php"
+        ],
+        "external": []
+      },
+      "importedBy": ["wp-plugin/admin/class-dashboard-widget.php"]
+    },
+    {
+      "path": "lib/events/trackers/class-post-tracker.php",
+      "namespace": "Sybgo\\Events\\Trackers",
+      "exports": ["Post_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/database/class-event-repository.php",
+          "lib/events/abstracts/class-abstract-singular-event.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/events/trackers/class-update-tracker.php",
+      "namespace": "Sybgo\\Events\\Trackers",
+      "exports": ["Update_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/database/class-event-repository.php",
+          "lib/events/abstracts/class-abstract-singular-event.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/events/trackers/class-user-tracker.php",
+      "namespace": "Sybgo\\Events\\Trackers",
+      "exports": ["User_Tracker"],
+      "imports": {
+        "internal": [
+          "lib/database/class-event-repository.php",
+          "lib/events/abstracts/class-abstract-singular-event.php"
+        ],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "lib/reports/class-report-generator.php",
+      "namespace": "Sybgo\\Reports",
+      "exports": ["Report_Generator"],
+      "imports": {
+        "internal": [
+          "lib/database/class-event-repository.php",
+          "lib/database/class-report-repository.php"
+        ],
+        "external": []
+      },
+      "importedBy": [
+        "wp-plugin/admin/class-dashboard-widget.php",
+        "wp-plugin/admin/class-reports-page.php"
+      ]
+    },
+    {
+      "path": "lib/reports/class-report-manager.php",
+      "namespace": "Sybgo\\Reports",
+      "exports": ["Report_Manager"],
+      "imports": {
+        "internal": [
+          "lib/database/class-aggregated-event-repository.php",
+          "lib/database/class-event-repository.php",
+          "lib/database/class-report-repository.php"
+        ],
+        "external": []
+      },
+      "importedBy": ["wp-plugin/admin/class-reports-page.php"]
+    }
+  ]
+}

--- a/.claude/knowledge-graph/modules/tests-e2e.json
+++ b/.claude/knowledge-graph/modules/tests-e2e.json
@@ -1,0 +1,209 @@
+{
+  "module": "tests-e2e",
+  "path": "tests/e2e",
+  "files": [
+    {
+      "path": "tests/e2e/playwright.config.ts",
+      "exports": ["default (PlaywrightTestConfig)"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/fixtures/auth.ts",
+      "exports": ["test", "expect"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": [
+        "tests/e2e/specs/dashboard-navigation.spec.ts",
+        "tests/e2e/specs/dashboard-widget.spec.ts",
+        "tests/e2e/specs/email-delivery.spec.ts",
+        "tests/e2e/specs/error-tracker-cap.spec.ts",
+        "tests/e2e/specs/report-status-ui.spec.ts",
+        "tests/e2e/specs/reports-lifecycle.spec.ts",
+        "tests/e2e/specs/settings.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ]
+    },
+    {
+      "path": "tests/e2e/fixtures/wp-cli.ts",
+      "exports": ["wpCli fixture"],
+      "imports": {
+        "internal": [],
+        "external": ["node:child_process"]
+      },
+      "importedBy": [
+        "tests/e2e/specs/dashboard-navigation.spec.ts",
+        "tests/e2e/specs/dashboard-widget.spec.ts",
+        "tests/e2e/specs/email-delivery.spec.ts",
+        "tests/e2e/specs/error-tracker-cap.spec.ts",
+        "tests/e2e/specs/report-status-ui.spec.ts",
+        "tests/e2e/specs/reports-lifecycle.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ]
+    },
+    {
+      "path": "tests/e2e/page-objects/dashboard-widget.ts",
+      "exports": ["DashboardWidgetPage"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": [
+        "tests/e2e/specs/dashboard-navigation.spec.ts",
+        "tests/e2e/specs/dashboard-widget.spec.ts",
+        "tests/e2e/specs/error-tracker-cap.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ]
+    },
+    {
+      "path": "tests/e2e/page-objects/report-details.ts",
+      "exports": ["ReportDetailsPage"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": [
+        "tests/e2e/specs/dashboard-navigation.spec.ts",
+        "tests/e2e/specs/report-status-ui.spec.ts",
+        "tests/e2e/specs/reports-lifecycle.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ]
+    },
+    {
+      "path": "tests/e2e/page-objects/reports-list.ts",
+      "exports": ["ReportsListPage"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": [
+        "tests/e2e/specs/email-delivery.spec.ts",
+        "tests/e2e/specs/report-status-ui.spec.ts",
+        "tests/e2e/specs/reports-lifecycle.spec.ts",
+        "tests/e2e/specs/smoke.spec.ts"
+      ]
+    },
+    {
+      "path": "tests/e2e/page-objects/settings.ts",
+      "exports": ["SettingsPage"],
+      "imports": {
+        "internal": [],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": ["tests/e2e/specs/settings.spec.ts"]
+    },
+    {
+      "path": "tests/e2e/specs/dashboard-navigation.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/dashboard-widget.ts",
+          "tests/e2e/page-objects/report-details.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/dashboard-widget.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/dashboard-widget.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/email-delivery.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/reports-list.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/error-tracker-cap.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/dashboard-widget.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/report-status-ui.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/report-details.ts",
+          "tests/e2e/page-objects/reports-list.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/reports-lifecycle.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/report-details.ts",
+          "tests/e2e/page-objects/reports-list.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/settings.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/page-objects/settings.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "tests/e2e/specs/smoke.spec.ts",
+      "exports": [],
+      "imports": {
+        "internal": [
+          "tests/e2e/fixtures/auth.ts",
+          "tests/e2e/fixtures/wp-cli.ts",
+          "tests/e2e/page-objects/dashboard-widget.ts",
+          "tests/e2e/page-objects/report-details.ts",
+          "tests/e2e/page-objects/reports-list.ts"
+        ],
+        "external": ["@playwright/test"]
+      },
+      "importedBy": []
+    }
+  ]
+}

--- a/.claude/knowledge-graph/modules/wp-plugin.json
+++ b/.claude/knowledge-graph/modules/wp-plugin.json
@@ -1,0 +1,102 @@
+{
+  "module": "wp-plugin",
+  "path": "wp-plugin",
+  "rootNamespace": "Sybgo\\Admin",
+  "files": [
+    {
+      "path": "wp-plugin/class-sybgo.php",
+      "namespace": "Sybgo",
+      "exports": ["Sybgo"],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": ["wp-plugin/admin/class-uninstaller.php"]
+    },
+    {
+      "path": "wp-plugin/uninstall.php",
+      "namespace": null,
+      "exports": [],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "wp-plugin/assets/js/admin.js",
+      "namespace": null,
+      "exports": [],
+      "imports": {
+        "internal": [],
+        "external": []
+      },
+      "importedBy": []
+    },
+    {
+      "path": "wp-plugin/admin/class-dashboard-widget.php",
+      "namespace": "Sybgo\\Admin",
+      "exports": ["Dashboard_Widget"],
+      "imports": {
+        "internal": ["wp-plugin/class-sybgo.php"],
+        "external": [
+          "lib/database/class-aggregated-event-repository.php",
+          "lib/database/class-event-repository.php",
+          "lib/database/class-report-repository.php",
+          "lib/reports/class-report-generator.php",
+          "lib/ai/class-ai-summarizer.php",
+          "lib/events/class-event-registry.php",
+          "lib/events/trackers/class-error-tracker.php"
+        ]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "wp-plugin/admin/class-reports-page.php",
+      "namespace": "Sybgo\\Admin",
+      "exports": ["Reports_Page"],
+      "imports": {
+        "internal": [],
+        "external": [
+          "lib/database/class-aggregated-event-repository.php",
+          "lib/database/class-event-repository.php",
+          "lib/database/class-report-repository.php",
+          "lib/reports/class-report-manager.php",
+          "lib/reports/class-report-generator.php",
+          "lib/email/class-email-manager.php",
+          "lib/events/class-event-registry.php",
+          "lib/ai/class-ai-summarizer.php"
+        ]
+      },
+      "importedBy": []
+    },
+    {
+      "path": "wp-plugin/admin/class-settings-page.php",
+      "namespace": "Sybgo\\Admin",
+      "exports": ["Settings_Page"],
+      "imports": {
+        "internal": [],
+        "external": [
+          "lib/database/class-db-stats.php",
+          "lib/events/class-event-registry.php"
+        ]
+      },
+      "importedBy": ["wp-plugin/admin/class-uninstaller.php"]
+    },
+    {
+      "path": "wp-plugin/admin/class-uninstaller.php",
+      "namespace": "Sybgo\\Admin",
+      "exports": ["Uninstaller"],
+      "imports": {
+        "internal": [
+          "wp-plugin/class-sybgo.php",
+          "wp-plugin/admin/class-settings-page.php"
+        ],
+        "external": [
+          "lib/database/class-databasemanager.php"
+        ]
+      },
+      "importedBy": []
+    }
+  ]
+}

--- a/.claude/knowledge-graph/summary.json
+++ b/.claude/knowledge-graph/summary.json
@@ -1,0 +1,42 @@
+{
+  "modules": [
+    {
+      "name": "lib",
+      "path": "lib",
+      "manifest": "lib/composer.json",
+      "fileCount": 24,
+      "languages": ["php"],
+      "rootNamespace": "Sybgo",
+      "entryPoints": [],
+      "externalDeps": ["berlindb/core", "wp-media/apply-filters-typed"],
+      "dependsOn": [],
+      "dependedOnBy": ["wp-plugin"]
+    },
+    {
+      "name": "wp-plugin",
+      "path": "wp-plugin",
+      "manifest": "wp-plugin/composer.json",
+      "fileCount": 7,
+      "languages": ["php", "javascript"],
+      "rootNamespace": "Sybgo\\Admin",
+      "entryPoints": ["wp-plugin/class-sybgo.php", "wp-plugin/uninstall.php"],
+      "externalDeps": ["wp-media/sybgo-lib"],
+      "dependsOn": ["lib"],
+      "dependedOnBy": []
+    },
+    {
+      "name": "tests-e2e",
+      "path": "tests/e2e",
+      "manifest": "tests/e2e/package.json",
+      "fileCount": 14,
+      "languages": ["typescript"],
+      "entryPoints": ["tests/e2e/playwright.config.ts"],
+      "externalDeps": ["@playwright/test", "@types/node", "typescript"],
+      "dependsOn": [],
+      "dependedOnBy": []
+    }
+  ],
+  "edges": [
+    { "from": "wp-plugin", "to": "lib", "weight": 18 }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,17 @@ cd wp-plugin && vendor/bin/phpstan analyse --memory-limit=1G
 cd wp-plugin && composer reinstall wp-media/sybgo-lib && vendor/bin/phpstan clear-result-cache
 ```
 
+## Knowledge Graph
+
+A pre-built dependency graph exists at `.claude/knowledge-graph/`. Before exploring the codebase for dependency or import information:
+
+1. Read `.claude/knowledge-graph/meta.json` to check freshness (compare `lastCommitHash` with `git rev-parse HEAD`)
+2. If the graph is stale or missing, invoke the `knowledge-graph` agent before proceeding — do not fall back to manual scanning
+3. Read `.claude/knowledge-graph/summary.json` for module-level dependencies
+4. For file-level detail, read the relevant `.claude/knowledge-graph/modules/<module>.json`
+
+Available modules: `lib` (PHP library), `wp-plugin` (WordPress plugin), `tests-e2e` (Playwright E2E tests).
+
 ## Post-implementation workflow (autonomous)
 
 Before implementing, estimate the diff size. If it exceeds ~100 meaningful lines (excluding docs, CSS, tests, generated code), split into independently shippable steps and implement them sequentially. Apply the below workflow for the first step and wait for human approval before moving to the next step.


### PR DESCRIPTION
# Description

Implements the knowledge-graph agent from [gas-delivery-pipeline-templates MR !1](https://gitlab.group.one/cpo-eng/gas/gas-delivery-pipeline-templates/-/merge_requests/1) in sybgo. This gives every AI coding session an instant map of the repository's dependency structure — without re-scanning the codebase from scratch each time.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Chore

## Detailed scenario

### What was tested

Manually verified the full scan on the current `develop` HEAD (`edb5178`):

1. Confirmed `.claude/knowledge-graph/meta.json` did not exist before the scan.
2. Ran the agent process step-by-step: collected all tracked PHP/TS/JS files via `git ls-files`, excluded vendor/node_modules/Tests directories, detected three modules from their manifests (`lib/composer.json`, `wp-plugin/composer.json`, `tests/e2e/package.json`).
3. Extracted all `namespace` and `use` statements from every PHP file using grep; extracted all `import … from` statements from every TypeScript file.
4. Classified each import as internal (resolves to a file in the repo) or external (third-party package) by matching against the `Sybgo\` root namespace and relative path heuristics.
5. Verified the generated JSON files are well-formed and that `importedBy` arrays are consistent with the `imports.internal` arrays across all files.
6. Checked that no circular dependencies exist between modules (lib ← wp-plugin, one-directional).

Results: 45 source files across 3 modules, 18 cross-module dependency edges from `wp-plugin` to `lib`, 0 circular dependencies.

### How to test

1. Clone the branch and open the repo in Claude Code.
2. In a new session, ask Claude: *"What modules does sybgo have and what are their dependencies?"*
   — Claude should read `.claude/knowledge-graph/meta.json` first (per the new CLAUDE.md section), then `.claude/knowledge-graph/summary.json`, and answer without scanning source files.
3. Ask: *"Which files import `Report_Repository`?"*
   — Claude should read `.claude/knowledge-graph/modules/lib.json` and return `importedBy` for that file without grepping.
4. Make a small code change (e.g., add a `use` statement to any PHP file), commit it, then invoke the `knowledge-graph` agent:
   — Agent should detect the stale hash in `meta.json`, run `git diff <old-hash>..HEAD --name-only`, and do an incremental scan of only the changed file.
5. Verify `.claude/knowledge-graph/meta.json` is updated with the new `lastCommitHash` after the incremental scan.

### Affected Features & Quality Assurance Scope

This is an AI-tooling addition only. No plugin PHP code, no WordPress hooks, no database, no admin UI. The only runtime change is the new CLAUDE.md section, which is read exclusively by Claude Code at session start.

## Technical description

### Documentation

**How it works:**

The knowledge-graph agent (`.claude/agents/knowledge-graph.md`) runs inside Claude Code's sub-agent framework. When invoked, it:

1. **Smart scan mode** — reads `meta.json` to compare `lastCommitHash` with `git rev-parse HEAD`. Full scan on first run; incremental on subsequent runs (only files changed since the last scan, plus their reverse-dependants); falls back to full scan if >50% of tracked files changed.

2. **File collection** — uses `git ls-files` filtered by extension (`.php`, `.ts`, `.js`, etc.) with standard exclusions (`vendor/`, `node_modules/`, `Tests/`, `build/`, …).

3. **Module detection** — locates manifest files (`composer.json`, `package.json`) up to 3 levels deep; each manifest directory is a module.

4. **Import/export extraction** — applies language-specific regex patterns:
   - PHP: `^use\s+([\w\\]+)` for use-statements, `^namespace\s+([\w\\]+)` for exports.
   - TypeScript: `import\s+.*\s+from\s+['"]([^'"]+)['"]` for static imports.
   Classifies each import as internal (matches root namespace / relative path) or external (third-party).

5. **Four output files** in `.claude/knowledge-graph/`:
   - `meta.json` — scan metadata and commit hash for freshness checks.
   - `summary.json` — module-level graph with edge weights; always small (<100 lines), loaded every session.
   - `modules/<name>.json` — file-level detail per module, loaded on demand.
   - `externals.json` — third-party dependency map.

**CLAUDE.md change** — adds a "Knowledge Graph" section instructing Claude Code to check graph freshness and read the graph files before doing any dependency exploration, eliminating redundant repo-scanning.

**Sybgo-specific adaptations** in the agent file:
- Both `lib/` and `wp-plugin/` share the `Sybgo\` root namespace; the agent uses sub-namespace patterns to distinguish internal-to-lib vs cross-module imports.
- Excluded directories extended with `site/`, `bin/`, `Tests/`.
- Entry points documented: `wp-plugin/class-sybgo.php` (plugin bootstrap) and `tests/e2e/playwright.config.ts`.

<details>
<summary>Generated graph structure</summary>

```
.claude/knowledge-graph/
├── meta.json          — commit edb5178, 45 files, 3 modules
├── summary.json       — module-level edges (wp-plugin → lib, weight 18)
├── externals.json     — berlindb/core, wp-media/apply-filters-typed, @playwright/test, …
└── modules/
    ├── lib.json        — 24 PHP files with full import/importedBy graph
    ├── wp-plugin.json  — 7 files (4 admin pages + main class + JS + uninstall)
    └── tests-e2e.json  — 14 TypeScript files (fixtures, page-objects, specs)
```

</details>

### New dependencies

None. The agent uses only tools already available in Claude Code (`Bash`, `Read`, `Glob`, `Grep`, `Write`).

### Risks

None identified. The agent writes only to `.claude/knowledge-graph/` which is a non-functional directory. No WordPress hooks, no database schema changes, no PHP autoloader modifications.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

**Built-in tests**: The deliverable is an AI agent instruction file and generated JSON data — there is no executable code to unit-test. The agent's correctness is validated by the manual test scenario in "How to test".

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)