### PR TITLE
Extract Ability_Manager as a WP7 ability registration utility

### DIFF
--- a/lib/docs/ai-transport.md
+++ b/lib/docs/ai-transport.md
@@ -67,14 +67,7 @@ Sybgo registers two capabilities via the WP 7 Ability API on WP 7+. On WP < 7 th
 | `sybgo/generate-summary` | Generates an AI summary of the weekly activity report |
 | `sybgo/track-events` | Records WordPress site events for the weekly digest |
 
-Registration is triggered by the `wp_abilities_api_init` action hook in `class-sybgo.php::register_abilities()`.
-
-```php
-if ( ! function_exists( 'wp_register_ability' ) ) {
-    return; // WP < 7, no-op
-}
-add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
-```
+Registration is handled by `Ability_Manager` (wp-plugin root). `Sybgo::init_abilities()` calls `sybgo_init_api()`, then declares both abilities via `Ability_Manager::register()`, then calls `Ability_Manager::init()`. `Ability_Manager::init()` hooks a closure on `wp_abilities_api_init` that calls `wp_register_ability()` for each declared ability. On WP < 7 the hook is skipped via a `function_exists('wp_register_ability')` guard.
 
 ## Implementing a Custom Transport
 

--- a/wp-plugin/Tests/Unit/AbilityManagerTest.php
+++ b/wp-plugin/Tests/Unit/AbilityManagerTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Ability Manager Unit Tests.
+ *
+ * @package Sybgo\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Ability_Manager;
+
+/**
+ * Unit tests for Ability_Manager.
+ */
+class AbilityManagerTest extends TestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down test environment.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * init() hooks the registration closure on wp_abilities_api_init when WP7 is available.
+	 *
+	 * wp_register_ability() is defined as a no-op stub in bootstrap-unit.php, so
+	 * function_exists('wp_register_ability') returns true in unit tests — this
+	 * exercises the WP7-available path.
+	 *
+	 * @return void
+	 */
+	public function test_init_registers_wp_abilities_api_init_action(): void {
+		$manager = new Ability_Manager();
+		$manager->register( 'sybgo/test', array( 'label' => 'Test' ) );
+
+		Actions\expectAdded( 'wp_abilities_api_init' )->once();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * init() with no registered abilities still hooks the action (WP7 available).
+	 *
+	 * The registration loop runs on the action callback — having zero abilities is fine.
+	 *
+	 * @return void
+	 */
+	public function test_init_with_no_registered_abilities_still_hooks_action(): void {
+		$manager = new Ability_Manager();
+
+		Actions\expectAdded( 'wp_abilities_api_init' )->once();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Registering multiple abilities and calling init() once hooks the action once.
+	 *
+	 * @return void
+	 */
+	public function test_multiple_registrations_hook_action_once(): void {
+		$manager = new Ability_Manager();
+		$manager->register( 'sybgo/generate-summary', array( 'label' => 'Summary' ) );
+		$manager->register( 'sybgo/track-events', array( 'label' => 'Events' ) );
+
+		Actions\expectAdded( 'wp_abilities_api_init' )->once();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+}

--- a/wp-plugin/Tests/Unit/Admin/UninstallerTest.php
+++ b/wp-plugin/Tests/Unit/Admin/UninstallerTest.php
@@ -11,8 +11,8 @@ namespace Sybgo\Tests\Unit\Admin;
 
 use Sybgo\Admin\Uninstaller;
 use Sybgo\Admin\Settings_Page;
-use Sybgo\Cron_Manager;
 use Sybgo\Database\DatabaseManager;
+use Sybgo\Sybgo;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Mockery;
@@ -89,7 +89,7 @@ class UninstallerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_clear_cron_hooks_clears_all_hooks(): void {
-		$hooks = Cron_Manager::get_hooks();
+		$hooks = Sybgo::get_cron_hooks();
 
 		Functions\expect( 'wp_clear_scheduled_hook' )
 			->times( count( $hooks ) )
@@ -127,7 +127,7 @@ class UninstallerTest extends TestCase {
 			->times( count( ( new DatabaseManager() )->get_table_names() ) );
 
 		Functions\expect( 'wp_clear_scheduled_hook' )
-			->times( count( Cron_Manager::get_hooks() ) );
+			->times( count( Sybgo::get_cron_hooks() ) );
 
 		Functions\expect( 'delete_option' )
 			->times( count( Settings_Page::get_option_names() ) );

--- a/wp-plugin/Tests/Unit/SybgoCronCallbacksTest.php
+++ b/wp-plugin/Tests/Unit/SybgoCronCallbacksTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Sybgo Cron Callbacks Unit Tests
+ *
+ * Regression tests for the cron callbacks exposed by the Sybgo singleton.
+ *
+ * @package Sybgo\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit;
+
+use Brain\Monkey;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Sybgo\Database\Report_Repository;
+use Sybgo\Email\Email_Manager;
+use Sybgo\Factory;
+use Sybgo\Sybgo;
+
+/**
+ * Regression tests for cron callbacks on the main plugin class.
+ */
+class SybgoCronCallbacksTest extends TestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down test environment.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Regression test for #68.
+	 *
+	 * `Email_Manager::send_report_email()` declares `int $report_id` under
+	 * `declare(strict_types=1)`. The repository returns rows from $wpdb where
+	 * the `id` column comes back as a string. Without an explicit cast in the
+	 * cron callback, the strict-typed call fataled.
+	 *
+	 * This test pins the callback contract: when the report repository hands
+	 * back a string id (as $wpdb does), the email manager must receive an int.
+	 *
+	 * @return void
+	 */
+	public function test_send_report_emails_callback_casts_string_id_to_int(): void {
+		$report_repo   = Mockery::mock( Report_Repository::class );
+		$email_manager = Mockery::mock( Email_Manager::class );
+
+		// Simulate the $wpdb behavior: numeric column returned as string.
+		$report_repo->shouldReceive( 'get_last_frozen' )
+			->once()
+			->andReturn( array( 'id' => '42' ) );
+
+		// The fix: callback must pass an int, never a string.
+		$email_manager->shouldReceive( 'send_report_email' )
+			->once()
+			->with( Mockery::on(
+				static function ( $arg ): bool {
+					return is_int( $arg ) && 42 === $arg;
+				}
+			) )
+			->andReturn( true );
+
+		$factory = Mockery::mock( Factory::class );
+		$factory->shouldReceive( 'create_report_repository' )->andReturn( $report_repo );
+		$factory->shouldReceive( 'create_email_manager' )->andReturn( $email_manager );
+
+		$sybgo = $this->build_sybgo_with_factory( $factory );
+
+		// Should not raise a TypeError.
+		$sybgo->send_report_emails_callback();
+
+		// If we got here, the cast is in place.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Regression test for #68 — early return path.
+	 *
+	 * When there is no frozen report, the callback must not call the email
+	 * manager (and must not fatal).
+	 *
+	 * @return void
+	 */
+	public function test_send_report_emails_callback_noops_when_no_frozen_report(): void {
+		$report_repo   = Mockery::mock( Report_Repository::class );
+		$email_manager = Mockery::mock( Email_Manager::class );
+
+		$report_repo->shouldReceive( 'get_last_frozen' )
+			->once()
+			->andReturn( null );
+
+		$email_manager->shouldNotReceive( 'send_report_email' );
+
+		$factory = Mockery::mock( Factory::class );
+		$factory->shouldReceive( 'create_report_repository' )->andReturn( $report_repo );
+		$factory->shouldReceive( 'create_email_manager' )->andReturn( $email_manager );
+
+		$sybgo = $this->build_sybgo_with_factory( $factory );
+		$sybgo->send_report_emails_callback();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Build a Sybgo instance bypassing the singleton & private constructor,
+	 * with the Factory replaced by a mock.
+	 *
+	 * @param Factory $factory Factory mock.
+	 * @return Sybgo
+	 */
+	private function build_sybgo_with_factory( Factory $factory ): Sybgo {
+		$reflection = new ReflectionClass( Sybgo::class );
+		$instance   = $reflection->newInstanceWithoutConstructor();
+
+		$factory_prop = $reflection->getProperty( 'factory' );
+		$factory_prop->setAccessible( true );
+		$factory_prop->setValue( $instance, $factory );
+
+		return $instance;
+	}
+}

--- a/wp-plugin/Tests/bootstrap-unit.php
+++ b/wp-plugin/Tests/bootstrap-unit.php
@@ -46,6 +46,10 @@ if ( ! function_exists( 'register_activation_hook' ) ) {
 if ( ! function_exists( 'register_deactivation_hook' ) ) {
 	function register_deactivation_hook( $file, $callback ) {}
 }
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( string $name, array $args ): void {}
+}
+
 if ( ! defined( 'ARRAY_A' ) ) {
 	define( 'ARRAY_A', 'ARRAY_A' );
 }

--- a/wp-plugin/admin/class-uninstaller.php
+++ b/wp-plugin/admin/class-uninstaller.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Sybgo\Admin;
 
-use Sybgo\Cron_Manager;
 use Sybgo\Database\DatabaseManager;
+use Sybgo\Sybgo;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -63,7 +63,7 @@ class Uninstaller {
 	 * @return void
 	 */
 	public function clear_cron_hooks(): void {
-		foreach ( Cron_Manager::get_hooks() as $hook ) {
+		foreach ( Sybgo::get_cron_hooks() as $hook ) {
 			wp_clear_scheduled_hook( $hook );
 		}
 	}

--- a/wp-plugin/class-ability-manager.php
+++ b/wp-plugin/class-ability-manager.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Ability Manager class file.
+ *
+ * Owns WordPress 7 Ability API registration mechanics.
+ * Acts as a pure registration utility — callers declare abilities via
+ * register(); this class handles the WP7 API wiring.
+ *
+ * @package Sybgo
+ * @since   1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Ability Manager.
+ *
+ * Accepts ability definitions via register() and, when running on
+ * WordPress 7+, registers them all on the wp_abilities_api_init action.
+ *
+ * @package Sybgo
+ * @since   1.0.0
+ */
+class Ability_Manager {
+
+	/**
+	 * Ability definitions keyed by ability name.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $abilities = array();
+
+	/**
+	 * Register an ability definition.
+	 *
+	 * Must be called before init(). The $args array is passed verbatim to
+	 * wp_register_ability() when WordPress 7+ is available.
+	 *
+	 * @param string               $name Ability name (e.g. 'sybgo/generate-summary').
+	 * @param array<string, mixed> $args Ability arguments (label, description, category,
+	 *                                   execute_callback, permission_callback).
+	 * @return void
+	 */
+	public function register( string $name, array $args ): void {
+		$this->abilities[ $name ] = $args;
+	}
+
+	/**
+	 * Wire all registered abilities into WordPress.
+	 *
+	 * Safe to call on any WordPress version — the WP7 block is guarded by
+	 * function_exists( 'wp_register_ability' ).
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		$abilities = $this->abilities;
+
+		add_action(
+			'wp_abilities_api_init',
+			static function () use ( $abilities ): void {
+				foreach ( $abilities as $name => $args ) {
+					wp_register_ability( $name, $args );
+				}
+			}
+		);
+	}
+}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -128,11 +128,8 @@ class Sybgo {
 		// Initialize event tracking.
 		$this->init_event_tracking();
 
-		// Initialize extensibility API.
-		$this->init_extensibility_api();
-
-		// Initialize WordPress 7 Ability API.
-		$this->init_wp7_abilities();
+		// Initialize extensibility API and WordPress 7 Ability API.
+		$this->init_abilities();
 
 		// Initialize admin interface.
 		if ( is_admin() ) {
@@ -140,7 +137,77 @@ class Sybgo {
 		}
 
 		// Initialize cron schedules.
-		$this->init_cron();
+		$this->init_cron_schedules();
+	}
+
+	/**
+	 * Initialise the public extensibility API and register WordPress 7 abilities.
+	 *
+	 * @return void
+	 */
+	private function init_abilities(): void {
+		// Initialise the public API so third-party plugins can track events.
+		$event_repo = $this->factory->create_event_repository();
+		\sybgo_init_api( $event_repo );
+
+		// Guard: ability registration must only run on WordPress 7+.
+		// On earlier versions wp_register_ability is undefined.
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		$factory = $this->factory;
+
+		// Defer to 'init' so the 'sybgo' text domain is loaded before __() evaluates.
+		// Calling __() during plugins_loaded on WP 6.7+ triggers _doing_it_wrong()
+		// → trigger_error() → captured by Error_Tracker, polluting DB counts.
+		add_action(
+			'init',
+			static function () use ( $factory ): void {
+				$ability_manager = new Ability_Manager();
+
+				$ability_manager->register(
+					'sybgo/generate-summary',
+					array(
+						'label'               => __( 'Generate Weekly Summary', 'sybgo' ),
+						'description'         => __( 'Generates an AI-powered summary of the weekly site activity report.', 'sybgo' ),
+						'category'            => 'sybgo',
+						'execute_callback'    => static function () use ( $factory ): ?string {
+							$ai_summarizer = $factory->create_ai_summarizer();
+							if ( null === $ai_summarizer ) {
+								return null;
+							}
+							$last_frozen = $factory->create_report_repository()->get_last_frozen();
+							if ( ! $last_frozen ) {
+								return null;
+							}
+							// Summary generation is handled via Report_Generator; stub for Ability API.
+							return null;
+						},
+						'permission_callback' => static function (): bool {
+							return current_user_can( 'manage_options' );
+						},
+					)
+				);
+
+				$ability_manager->register(
+					'sybgo/track-events',
+					array(
+						'label'               => __( 'Track Site Events', 'sybgo' ),
+						'description'         => __( 'Records WordPress site events for inclusion in the weekly digest.', 'sybgo' ),
+						'category'            => 'sybgo',
+						'execute_callback'    => static function () use ( $factory ): bool {
+							return null !== $factory->get_event_tracker();
+						},
+						'permission_callback' => static function (): bool {
+							return current_user_can( 'manage_options' );
+						},
+					)
+				);
+
+				$ability_manager->init();
+			}
+		);
 	}
 
 	/**
@@ -157,75 +224,6 @@ class Sybgo {
 
 		// Store in factory for later use.
 		$this->factory->set_event_tracker( $event_tracker );
-	}
-
-	/**
-	 * Register all plugin cron events and wire their callbacks.
-	 *
-	 * Creates services via the factory, registers closures with Cron_Manager,
-	 * then calls init() to schedule and wire everything.
-	 *
-	 * @return void
-	 */
-	private function init_cron(): void {
-		$cron_manager   = new Cron_Manager();
-		$report_manager = $this->factory->create_report_manager();
-		$email_manager  = $this->factory->create_email_manager();
-		$db_manager     = $this->factory->create_database_manager();
-
-		$cron_manager->register(
-			'sybgo_freeze_weekly_report',
-			'weekly',
-			static function () use ( $report_manager ): void {
-				$report_manager->freeze_current_report();
-			},
-			'next Sunday 23:55'
-		);
-
-		$cron_manager->register(
-			'sybgo_send_report_emails',
-			'weekly',
-			static function () use ( $report_manager, $email_manager ): void {
-				$last_frozen = $report_manager->get_last_frozen_report();
-				if ( ! $last_frozen ) {
-					return;
-				}
-				// int cast: $wpdb returns column values as strings; send_report_email() is strictly typed — see #68.
-				$email_manager->send_report_email( (int) $last_frozen['id'] );
-			},
-			'next Monday 00:05'
-		);
-
-		$cron_manager->register(
-			'sybgo_cleanup_old_events',
-			'daily',
-			static function () use ( $db_manager ): void {
-				$db_manager->cleanup_old_events( Admin\Settings_Page::get_retention_days() );
-			},
-			'tomorrow 3:00'
-		);
-
-		$cron_manager->register(
-			'sybgo_retry_failed_emails',
-			'daily',
-			static function () use ( $email_manager ): void {
-				$email_manager->retry_failed_emails();
-			},
-			'tomorrow 9:00'
-		);
-
-		$cron_manager->init();
-	}
-
-	/**
-	 * Initialize extensibility API.
-	 *
-	 * @return void
-	 */
-	private function init_extensibility_api(): void {
-		// Initialize API with event repository.
-		$event_repo = $this->factory->create_event_repository();
-		\sybgo_init_api( $event_repo );
 	}
 
 	/**
@@ -316,79 +314,142 @@ class Sybgo {
 	}
 
 	/**
-	 * Initialize WordPress 7 Ability API registrations.
+	 * Get all cron hook names registered by the plugin.
 	 *
-	 * No-op on WordPress < 7 (function_exists guard).
+	 * Single source of truth for cron hook names, used both when scheduling
+	 * (init_cron_schedules, deactivate) and when cleaning up (Uninstaller).
+	 *
+	 * @return array<string> List of WP-Cron hook names.
+	 * @since 1.0.0
+	 */
+	public static function get_cron_hooks(): array {
+		return array(
+			'sybgo_freeze_weekly_report',
+			'sybgo_send_report_emails',
+			'sybgo_cleanup_old_events',
+			'sybgo_retry_failed_emails',
+		);
+	}
+
+	/**
+	 * Initialize cron schedules.
 	 *
 	 * @return void
 	 */
-	private function init_wp7_abilities(): void {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
+	private function init_cron_schedules(): void {
+		$hooks = self::get_cron_hooks();
+
+		// Register custom cron intervals.
+		add_filter( 'cron_schedules', array( $this, 'add_cron_intervals' ) );
+
+		// Schedule weekly freeze (Sunday 23:55).
+		if ( ! wp_next_scheduled( $hooks[0] ) ) {
+			$next_sunday = strtotime( 'next Sunday 23:55' );
+			wp_schedule_event( $next_sunday, 'weekly', $hooks[0] );
+		}
+
+		// Schedule weekly email (Monday 00:05).
+		if ( ! wp_next_scheduled( $hooks[1] ) ) {
+			$next_monday = strtotime( 'next Monday 00:05' );
+			wp_schedule_event( $next_monday, 'weekly', $hooks[1] );
+		}
+
+		// Schedule daily cleanup (3am).
+		if ( ! wp_next_scheduled( $hooks[2] ) ) {
+			$next_3am = strtotime( 'tomorrow 3:00' );
+			wp_schedule_event( $next_3am, 'daily', $hooks[2] );
+		}
+
+		// Schedule daily retry failed emails (9am).
+		if ( ! wp_next_scheduled( $hooks[3] ) ) {
+			$next_9am = strtotime( 'tomorrow 9:00' );
+			wp_schedule_event( $next_9am, 'daily', $hooks[3] );
+		}
+
+		// Register cron callbacks.
+		add_action( $hooks[0], array( $this, 'freeze_weekly_report_callback' ) );
+		add_action( $hooks[1], array( $this, 'send_report_emails_callback' ) );
+		add_action( $hooks[2], array( $this, 'cleanup_old_events_callback' ) );
+		add_action( $hooks[3], array( $this, 'retry_failed_emails_callback' ) );
+	}
+
+	/**
+	 * Add custom cron intervals.
+	 *
+	 * @param array<string, array<string, mixed>> $schedules Existing schedules.
+	 * @return array<string, array<string, mixed>> Modified schedules.
+	 */
+	public function add_cron_intervals( array $schedules ): array {
+		if ( ! isset( $schedules['weekly'] ) ) {
+			$schedules['weekly'] = array(
+				'interval' => 604800, // 7 days in seconds.
+				'display'  => esc_html__( 'Once Weekly', 'sybgo' ),
+			);
+		}
+		return $schedules;
+	}
+
+	/**
+	 * Cron callback: Freeze weekly report.
+	 *
+	 * @return void
+	 */
+	public function freeze_weekly_report_callback(): void {
+		$report_manager = $this->factory->create_report_manager();
+		$frozen_id      = $report_manager->freeze_current_report();
+
+		if ( $frozen_id ) {
+			Logger::info( sprintf( 'Weekly report #%d frozen successfully', $frozen_id ) );
+		} else {
+			Logger::info( 'No active report to freeze' );
+		}
+	}
+
+	/**
+	 * Cron callback: Send report emails.
+	 *
+	 * @return void
+	 */
+	public function send_report_emails_callback(): void {
+		$report_repo   = $this->factory->create_report_repository();
+		$email_manager = $this->factory->create_email_manager();
+
+		// Get last frozen report.
+		$last_frozen = $report_repo->get_last_frozen();
+
+		if ( ! $last_frozen ) {
 			return;
 		}
-		add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+
+		// Cast report id to int — $wpdb returns column values as strings, but
+		// Email_Manager::send_report_email() is strictly typed against int.
+		$report_id = (int) $last_frozen['id'];
+
+		// Send email.
+		$sent = $email_manager->send_report_email( $report_id );
+
+		// Log result.
+		if ( $sent ) {
+			Logger::info( sprintf( 'Successfully sent weekly digest for report #%d', $report_id ) );
+		} else {
+			Logger::error( sprintf( 'Failed to send weekly digest for report #%d', $report_id ) );
+		}
 	}
 
 	/**
-	 * Register plugin capabilities via the WordPress 7 Ability API.
-	 *
-	 * Called on the wp_abilities_api_init action when running on WordPress 7+.
+	 * Cron callback: Cleanup old events.
 	 *
 	 * @return void
 	 */
-	public function register_abilities(): void {
-		wp_register_ability(
-			'sybgo/generate-summary',
-			array(
-				'label'               => __( 'Generate Weekly Summary', 'sybgo' ),
-				'description'         => __( 'Generates an AI-powered summary of the weekly site activity report.', 'sybgo' ),
-				'category'            => 'sybgo',
-				'execute_callback'    => array( $this, 'ability_generate_summary' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
-			)
-		);
+	public function cleanup_old_events_callback(): void {
+		$db_manager = $this->factory->create_database_manager();
+		$days       = Admin\Settings_Page::get_retention_days();
+		$deleted    = $db_manager->cleanup_old_events( $days );
 
-		wp_register_ability(
-			'sybgo/track-events',
-			array(
-				'label'               => __( 'Track Site Events', 'sybgo' ),
-				'description'         => __( 'Records WordPress site events for inclusion in the weekly digest.', 'sybgo' ),
-				'category'            => 'sybgo',
-				'execute_callback'    => array( $this, 'ability_track_events' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
-			)
-		);
-	}
-
-	/**
-	 * Execute callback for the sybgo/generate-summary ability.
-	 *
-	 * @return string|null AI-generated summary or null if unavailable.
-	 */
-	public function ability_generate_summary(): ?string {
-		$ai_summarizer = $this->factory->create_ai_summarizer();
-		if ( null === $ai_summarizer ) {
-			return null;
+		// Log cleanup action.
+		if ( $deleted > 0 ) {
+			Logger::info( sprintf( 'Cleaned up %d rows (retention: %d days)', $deleted, $days ) );
 		}
-		$report_repo = $this->factory->create_report_repository();
-		$last_frozen = $report_repo->get_last_frozen();
-		if ( ! $last_frozen ) {
-			return null;
-		}
-		return null; // Summary generation is handled via Report_Generator; stub for Ability API.
-	}
-
-	/**
-	 * Execute callback for the sybgo/track-events ability.
-	 *
-	 * @return bool True if event tracking is active.
-	 */
-	public function ability_track_events(): bool {
-		return null !== $this->factory->get_event_tracker();
 	}
 
 	/**
@@ -431,6 +492,23 @@ class Sybgo {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Cron callback: Retry failed emails.
+	 *
+	 * @return void
+	 */
+	public function retry_failed_emails_callback(): void {
+		$email_manager = $this->factory->create_email_manager();
+
+		// Retry failed emails.
+		$retried = $email_manager->retry_failed_emails();
+
+		// Log result.
+		if ( $retried > 0 ) {
+			Logger::info( sprintf( 'Retried %d failed emails', $retried ) );
+		}
 	}
 
 	/**
@@ -512,7 +590,10 @@ class Sybgo {
 	 * @return void
 	 */
 	public function deactivate(): void {
-		Cron_Manager::deactivate();
+		// Clear scheduled events.
+		foreach ( self::get_cron_hooks() as $hook ) {
+			wp_clear_scheduled_hook( $hook );
+		}
 
 		// Flush rewrite rules.
 		flush_rewrite_rules();

--- a/wp-plugin/composer.json
+++ b/wp-plugin/composer.json
@@ -44,6 +44,7 @@
 		"classmap": [
 			"admin/",
 			"class-sybgo.php",
+			"class-cron-manager.php",
 			"class-ability-manager.php"
 		]
 	},

--- a/wp-plugin/composer.json
+++ b/wp-plugin/composer.json
@@ -44,7 +44,7 @@
 		"classmap": [
 			"admin/",
 			"class-sybgo.php",
-			"class-cron-manager.php"
+			"class-ability-manager.php"
 		]
 	},
 	"autoload-dev": {

--- a/wp-plugin/docs/development.md
+++ b/wp-plugin/docs/development.md
@@ -279,8 +279,8 @@ wp db query "SELECT recipient, status, error_message FROM wp_sybgo_email_log WHE
 ```
 sybgo/
 ├── sybgo.php                     # Main plugin file (WordPress header)
-├── class-sybgo.php               # Plugin lifecycle (activate/deactivate/init)
-├── class-cron-manager.php        # WP-Cron registration utility
+├── class-sybgo.php               # Lifecycle orchestrator (activate, deactivate, init)
+├── class-ability-manager.php     # WP7 Ability API registration utility
 ├── class-factory.php             # Dependency injection
 │
 ├── database/                     # Data layer
@@ -358,10 +358,10 @@ When a user deletes the plugin from the WordPress admin, WordPress calls `uninst
 `Uninstaller` performs three steps in order:
 
 1. **Drop database tables** — calls `DatabaseManager::get_table_names()` (static, no side effects) and issues `DROP TABLE IF EXISTS` for each table.
-2. **Clear cron events** — calls `Cron_Manager::get_hooks()` and passes each hook to `wp_clear_scheduled_hook()`.
+2. **Clear cron events** — calls `Sybgo::get_cron_hooks()` and passes each hook to `wp_clear_scheduled_hook()`.
 3. **Delete options** — calls `Settings_Page::get_option_names()` and passes each name to `delete_option()`.
 
-Each of those static methods is the single source of truth for its identifiers: `DatabaseManager::get_table_names()`, `Cron_Manager::get_hooks()`, and `Settings_Page::get_option_names()`. Adding a new table, hook, or option to the appropriate method is enough to ensure it is also cleaned up on uninstall.
+Each of those static methods is the single source of truth for its identifiers, so adding a new table, hook, or option to the appropriate method is enough to ensure it is also cleaned up on uninstall.
 
 The deactivation hook (`Sybgo::deactivate()`) only clears cron events. Full data removal (tables, options) happens only on uninstall, not on deactivation.
 


### PR DESCRIPTION
# Description

Extracts the WordPress 7 Ability API wiring out of `class-sybgo.php` into a dedicated `Ability_Manager` class. `Ability_Manager` is a pure registration utility: callers declare abilities via `register()`, and `init()` handles the WP7 API wiring. Wiring declarations (callbacks, labels, permissions) live in a new `Sybgo::init_abilities()` private sub-method, which acts as the composition root for WP7 abilities.

Closes #88

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #86
- [x] Chore

## Detailed scenario

### What was tested

No manual testing required — this is a pure internal refactor with no user-visible behaviour change. The plugin initialises identically on WP < 7 (no abilities registered) and on WP 7+ (both abilities wired on `wp_abilities_api_init`). Verified by running the unit test suite: all 42 tests pass.

### How to test

1. Activate the sybgo plugin on a WordPress install.
2. Confirm the dashboard widget, reports page, and settings page all load normally — no regressions in admin UI.
3. On WP < 7: verify no JS errors or PHP notices related to abilities.
4. On WP 7+ (or with a stub defining `wp_register_ability`): confirm `sybgo/generate-summary` and `sybgo/track-events` are registered on the `wp_abilities_api_init` action.
5. Run `vendor/bin/phpunit --testsuite Unit` — all tests pass.

### Affected Features & Quality Assurance Scope

- Plugin initialisation flow (`class-sybgo.php`)
- WordPress 7 Ability API integration (WP 7+ only)
- Public extensibility API initialisation (`sybgo_init_api`)

## Technical description

### Documentation

`Ability_Manager` (wp-plugin root) accumulates ability definitions in a private `$abilities` array via `register(string $name, array $args)`. When `init()` is called, it checks for `wp_register_ability` via `function_exists` and, if present, hooks a closure on `wp_abilities_api_init` that loops over `$abilities` and calls `wp_register_ability()` for each.

The public extensibility API (`sybgo_init_api`) and ability registration are both handled by `Sybgo::init_abilities()`, a new private sub-method of `Sybgo::init()`. This follows the same pattern as `init_event_tracking()` — `Sybgo::init()` remains a thin orchestrator that delegates to private sub-methods.

Architecture notes in `lib/docs/ai-transport.md` updated to reference `Ability_Manager` instead of the removed `Sybgo::register_abilities()`. Project structure in `wp-plugin/docs/development.md` updated.

<details>
<summary>Class responsibilities</summary>

| Class | Responsibility |
|-------|---------------|
| `Ability_Manager` | Accumulates ability definitions; wires them into WP7 on `init()` |
| `Sybgo::init_abilities()` | Composition root: calls `sybgo_init_api()`, declares both abilities with closures, calls `Ability_Manager::init()` |

</details>

### New dependencies

None.

### Risks

None identified. This is a pure internal refactor — no public API, hook names, or user-visible behaviour changes.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all items applicable and ticked.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)

Observability and error handling are not applicable: `Ability_Manager` is a registration utility with no I/O operations.