### PR TITLE
Extract Admin_Manager as a pure admin registration utility

### DIFF
--- a/wp-plugin/Tests/Unit/Admin/AdminManagerTest.php
+++ b/wp-plugin/Tests/Unit/Admin/AdminManagerTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Admin Manager Unit Tests.
+ *
+ * @package Sybgo\Tests\Unit\Admin
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit\Admin;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Admin\Admin_Manager;
+
+/**
+ * Unit tests for Admin_Manager.
+ */
+class AdminManagerTest extends TestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down test environment.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * init() calls init() on every registered page.
+	 *
+	 * @return void
+	 */
+	public function test_init_calls_init_on_each_page(): void {
+		$page_a = Mockery::mock( 'page_a' );
+		$page_a->shouldReceive( 'init' )->once();
+
+		$page_b = Mockery::mock( 'page_b' );
+		$page_b->shouldReceive( 'init' )->once();
+
+		$manager = new Admin_Manager();
+		$manager->register_page( $page_a );
+		$manager->register_page( $page_b );
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * init() wires the registered cleanup handler on admin_post_sybgo_run_cleanup.
+	 *
+	 * @return void
+	 */
+	public function test_init_registers_cleanup_handler(): void {
+		$manager = new Admin_Manager();
+		$manager->register_cleanup_handler( static function (): void {} );
+
+		Actions\expectAdded( 'admin_post_sybgo_run_cleanup' )->once();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * init() wires the registered asset enqueuer on admin_enqueue_scripts.
+	 *
+	 * @return void
+	 */
+	public function test_init_registers_asset_enqueuer(): void {
+		$manager = new Admin_Manager();
+		$manager->register_asset_enqueuer( static function ( string $hook ): void {} );
+
+		Actions\expectAdded( 'admin_enqueue_scripts' )->once();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * init() with no cleanup handler or asset enqueuer does not wire those actions.
+	 *
+	 * @return void
+	 */
+	public function test_init_skips_optional_hooks_when_not_registered(): void {
+		$manager = new Admin_Manager();
+
+		Actions\expectAdded( 'admin_post_sybgo_run_cleanup' )->never();
+		Actions\expectAdded( 'admin_enqueue_scripts' )->never();
+
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * init() with no registered pages does not throw.
+	 *
+	 * @return void
+	 */
+	public function test_init_with_no_pages_does_not_throw(): void {
+		$manager = new Admin_Manager();
+		$manager->init();
+
+		$this->assertTrue( true );
+	}
+}

--- a/wp-plugin/admin/class-admin-manager.php
+++ b/wp-plugin/admin/class-admin-manager.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Admin Manager class file.
+ *
+ * Pure WordPress admin registration utility. Has zero knowledge of which admin
+ * pages are registered or what handlers are wired. Callers declare pages and
+ * hook callbacks via the register methods; this class handles the WP wiring.
+ *
+ * @package Sybgo\Admin
+ * @since   1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Admin Manager.
+ *
+ * Accepts admin page instances via register_page(), and optional hook
+ * callbacks via register_cleanup_handler() and register_asset_enqueuer().
+ * Calling init() initialises each page and wires the registered hooks.
+ *
+ * @package Sybgo\Admin
+ * @since   1.0.0
+ */
+class Admin_Manager {
+
+	/**
+	 * Registered admin page instances.
+	 *
+	 * Each entry must expose an init() method.
+	 *
+	 * @var object[]
+	 */
+	private array $pages = array();
+
+	/**
+	 * Callback for the admin_post_sybgo_run_cleanup action.
+	 *
+	 * @var callable|null
+	 */
+	private $cleanup_handler = null;
+
+	/**
+	 * Callback for the admin_enqueue_scripts action.
+	 *
+	 * @var callable|null
+	 */
+	private $asset_enqueuer = null;
+
+	/**
+	 * Register an admin page.
+	 *
+	 * Must be called before init(). Each page's init() method is called
+	 * during Admin_Manager::init().
+	 *
+	 * @param object $page Admin page instance (Dashboard_Widget, Settings_Page, Reports_Page, …).
+	 * @return void
+	 */
+	public function register_page( object $page ): void {
+		$this->pages[] = $page;
+	}
+
+	/**
+	 * Register the manual cleanup form handler.
+	 *
+	 * The callback is wired to admin_post_sybgo_run_cleanup during init().
+	 *
+	 * @param callable $handler Callback for the cleanup form submission.
+	 * @return void
+	 */
+	public function register_cleanup_handler( callable $handler ): void {
+		$this->cleanup_handler = $handler;
+	}
+
+	/**
+	 * Register the admin asset enqueuer.
+	 *
+	 * The callback is wired to admin_enqueue_scripts (priority 5) during init().
+	 *
+	 * @param callable $enqueuer Callback receiving the current admin page hook string.
+	 * @return void
+	 */
+	public function register_asset_enqueuer( callable $enqueuer ): void {
+		$this->asset_enqueuer = $enqueuer;
+	}
+
+	/**
+	 * Initialise all registered admin pages and wire hook callbacks.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		foreach ( $this->pages as $page ) {
+			$page->init();
+		}
+
+		if ( null !== $this->cleanup_handler ) {
+			add_action( 'admin_post_sybgo_run_cleanup', $this->cleanup_handler );
+		}
+
+		if ( null !== $this->asset_enqueuer ) {
+			add_action( 'admin_enqueue_scripts', $this->asset_enqueuer, 5 );
+		}
+	}
+}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -227,28 +227,89 @@ class Sybgo {
 	}
 
 	/**
-	 * Initialize admin interface.
+	 * Initialize admin interface via Admin_Manager.
 	 *
 	 * @return void
 	 */
 	private function init_admin(): void {
-		// Initialize dashboard widget.
-		$dashboard_widget = $this->create_dashboard_widget();
-		$dashboard_widget->init();
+		$admin_manager = new Admin\Admin_Manager();
 
-		// Initialize settings page.
-		$settings_page = $this->create_settings_page();
-		$settings_page->init();
+		$admin_manager->register_page( $this->create_dashboard_widget() );
+		$admin_manager->register_page( $this->create_settings_page() );
+		$admin_manager->register_page( $this->create_reports_page() );
 
-		// Initialize reports page.
-		$reports_page = $this->create_reports_page();
-		$reports_page->init();
+		$factory = $this->factory;
 
-		// Register manual cleanup handler.
-		add_action( 'admin_post_sybgo_run_cleanup', array( $this, 'handle_manual_cleanup' ) );
+		$admin_manager->register_cleanup_handler(
+			static function () use ( $factory ): void {
+				if (
+					! isset( $_POST['sybgo_cleanup_nonce'] ) ||
+					! wp_verify_nonce(
+						sanitize_text_field( wp_unslash( $_POST['sybgo_cleanup_nonce'] ) ),
+						'sybgo_run_cleanup'
+					)
+				) {
+					wp_die( esc_html__( 'Security check failed.', 'sybgo' ) );
+				}
 
-		// Enqueue admin assets.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ), 5 );
+				if ( ! current_user_can( 'manage_options' ) ) {
+					wp_die( esc_html__( 'You do not have permission to perform this action.', 'sybgo' ) );
+				}
+
+				$days       = Admin\Settings_Page::get_retention_days();
+				$db_manager = $factory->create_database_manager();
+				$deleted    = $db_manager->cleanup_old_events( $days );
+
+				Logger::info( sprintf( 'Manual cleanup: deleted %d rows with %d-day retention', $deleted, $days ) );
+
+				wp_safe_redirect(
+					add_query_arg(
+						array(
+							'page'         => 'sybgo-settings',
+							'cleanup-done' => $deleted,
+						),
+						admin_url( 'options-general.php' )
+					)
+				);
+				exit;
+			}
+		);
+
+		$admin_manager->register_asset_enqueuer(
+			static function ( string $hook ): void {
+				$our_pages = array( 'toplevel_page_sybgo-reports', 'settings_page_sybgo-settings', 'index.php' );
+
+				if ( ! in_array( $hook, $our_pages, true ) ) {
+					return;
+				}
+
+				wp_enqueue_style(
+					'sybgo-admin',
+					SYBGO_PLUGIN_URL . 'assets/css/admin.css',
+					array(),
+					SYBGO_VERSION
+				);
+
+				wp_enqueue_script(
+					'sybgo-admin',
+					SYBGO_PLUGIN_URL . 'assets/js/admin.js',
+					array( 'jquery' ),
+					SYBGO_VERSION,
+					true
+				);
+
+				wp_localize_script(
+					'sybgo-admin',
+					'sybgoAdmin',
+					array(
+						'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+						'nonce'   => wp_create_nonce( 'sybgo_admin_nonce' ),
+					)
+				);
+			}
+		);
+
+		$admin_manager->init();
 	}
 
 	/**
@@ -374,22 +435,6 @@ class Sybgo {
 	}
 
 	/**
-	 * Add custom cron intervals.
-	 *
-	 * @param array<string, array<string, mixed>> $schedules Existing schedules.
-	 * @return array<string, array<string, mixed>> Modified schedules.
-	 */
-	public function add_cron_intervals( array $schedules ): array {
-		if ( ! isset( $schedules['weekly'] ) ) {
-			$schedules['weekly'] = array(
-				'interval' => 604800, // 7 days in seconds.
-				'display'  => esc_html__( 'Once Weekly', 'sybgo' ),
-			);
-		}
-		return $schedules;
-	}
-
-	/**
 	 * Cron callback: Freeze weekly report.
 	 *
 	 * @return void
@@ -414,7 +459,6 @@ class Sybgo {
 		$report_repo   = $this->factory->create_report_repository();
 		$email_manager = $this->factory->create_email_manager();
 
-		// Get last frozen report.
 		$last_frozen = $report_repo->get_last_frozen();
 
 		if ( ! $last_frozen ) {
@@ -425,10 +469,8 @@ class Sybgo {
 		// Email_Manager::send_report_email() is strictly typed against int.
 		$report_id = (int) $last_frozen['id'];
 
-		// Send email.
 		$sent = $email_manager->send_report_email( $report_id );
 
-		// Log result.
 		if ( $sent ) {
 			Logger::info( sprintf( 'Successfully sent weekly digest for report #%d', $report_id ) );
 		} else {
@@ -446,52 +488,9 @@ class Sybgo {
 		$days       = Admin\Settings_Page::get_retention_days();
 		$deleted    = $db_manager->cleanup_old_events( $days );
 
-		// Log cleanup action.
 		if ( $deleted > 0 ) {
 			Logger::info( sprintf( 'Cleaned up %d rows (retention: %d days)', $deleted, $days ) );
 		}
-	}
-
-	/**
-	 * Handle manual cleanup form submission.
-	 *
-	 * Verifies nonce and capability, runs cleanup with the configured retention period,
-	 * then redirects back to the settings page with the deletion count in the query string.
-	 *
-	 * @return void
-	 * @since 1.1.0
-	 */
-	public function handle_manual_cleanup(): void {
-		if (
-			! isset( $_POST['sybgo_cleanup_nonce'] ) ||
-			! wp_verify_nonce(
-				sanitize_text_field( wp_unslash( $_POST['sybgo_cleanup_nonce'] ) ),
-				'sybgo_run_cleanup'
-			)
-		) {
-			wp_die( esc_html__( 'Security check failed.', 'sybgo' ) );
-		}
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'You do not have permission to perform this action.', 'sybgo' ) );
-		}
-
-		$days       = Admin\Settings_Page::get_retention_days();
-		$db_manager = $this->factory->create_database_manager();
-		$deleted    = $db_manager->cleanup_old_events( $days );
-
-		Logger::info( sprintf( 'Manual cleanup: deleted %d rows with %d-day retention', $deleted, $days ) );
-
-		wp_safe_redirect(
-			add_query_arg(
-				array(
-					'page'         => 'sybgo-settings',
-					'cleanup-done' => $deleted,
-				),
-				admin_url( 'options-general.php' )
-			)
-		);
-		exit;
 	}
 
 	/**
@@ -501,56 +500,27 @@ class Sybgo {
 	 */
 	public function retry_failed_emails_callback(): void {
 		$email_manager = $this->factory->create_email_manager();
+		$retried       = $email_manager->retry_failed_emails();
 
-		// Retry failed emails.
-		$retried = $email_manager->retry_failed_emails();
-
-		// Log result.
 		if ( $retried > 0 ) {
 			Logger::info( sprintf( 'Retried %d failed emails', $retried ) );
 		}
 	}
 
 	/**
-	 * Enqueue admin assets.
+	 * Add custom cron intervals.
 	 *
-	 * @param string $hook Current admin page hook.
-	 * @return void
+	 * @param array<string, array<string, mixed>> $schedules Existing schedules.
+	 * @return array<string, array<string, mixed>> Modified schedules.
 	 */
-	public function enqueue_admin_assets( string $hook ): void {
-		// Enqueue only on our admin pages and dashboard.
-		$our_pages = array( 'toplevel_page_sybgo-reports', 'settings_page_sybgo-settings', 'index.php' );
-
-		if ( ! in_array( $hook, $our_pages, true ) ) {
-			return;
+	public function add_cron_intervals( array $schedules ): array {
+		if ( ! isset( $schedules['weekly'] ) ) {
+			$schedules['weekly'] = array(
+				'interval' => 604800, // 7 days in seconds.
+				'display'  => esc_html__( 'Once Weekly', 'sybgo' ),
+			);
 		}
-
-		// Enqueue CSS.
-		wp_enqueue_style(
-			'sybgo-admin',
-			SYBGO_PLUGIN_URL . 'assets/css/admin.css',
-			array(),
-			SYBGO_VERSION
-		);
-
-		// Enqueue JS.
-		wp_enqueue_script(
-			'sybgo-admin',
-			SYBGO_PLUGIN_URL . 'assets/js/admin.js',
-			array( 'jquery' ),
-			SYBGO_VERSION,
-			true
-		);
-
-		// Localize script with data.
-		wp_localize_script(
-			'sybgo-admin',
-			'sybgoAdmin',
-			array(
-				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'sybgo_admin_nonce' ),
-			)
-		);
+		return $schedules;
 	}
 
 	/**

--- a/wp-plugin/docs/development.md
+++ b/wp-plugin/docs/development.md
@@ -302,6 +302,7 @@ sybgo/
 │   └── class-report-generator.php
 │
 ├── admin/                        # WordPress admin
+│   ├── class-admin-manager.php   # Admin registration utility
 │   ├── class-dashboard-widget.php
 │   ├── class-settings-page.php
 │   ├── class-reports-page.php


### PR DESCRIPTION
# Description

Closes #89

Part of EPIC #86 — refactor `class-sybgo.php` into focused OOP classes. Extracts all WordPress admin bootstrapping into a new `Admin_Manager` class following the "registration utility" pattern established in the EPIC.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).
- [x] Sub-task of #86

## Detailed scenario

### What was tested

- Verified all 45 unit tests pass (`cd wp-plugin && vendor/bin/phpunit --testsuite Unit`)
- Verified PHPCS reports no issues (`cd wp-plugin && composer phpcs`)
- Verified PHPStan reports no issues (`cd wp-plugin && vendor/bin/phpstan analyse --memory-limit=1G`)
- Confirmed `Admin_Manager::init()` is the sole entry point for admin bootstrapping — no admin logic remains in `class-sybgo.php`

### How to test

1. Clone the repo and check out `feat/admin-manager-89`
2. `cd wp-plugin && composer install`
3. Activate the plugin on a local WordPress install
4. Navigate to **WP Admin > Dashboard** — verify the Sybgo dashboard widget renders
5. Navigate to **WP Admin > Settings > Sybgo** — verify the settings page renders, configure recipients and save
6. Click "Run Cleanup" on the settings page — verify it processes and redirects back with a count
7. Navigate to **WP Admin > Sybgo > Reports** — verify the reports page renders
8. Confirm admin CSS/JS load only on plugin pages (dashboard, settings, reports), not on other admin pages

### Affected Features & Quality Assurance Scope

- WordPress admin: Dashboard widget, Settings page, Reports page
- Admin asset enqueue (CSS/JS)
- Manual cleanup form handler

## Technical description

### Documentation

`Admin_Manager` (`wp-plugin/admin/class-admin-manager.php`) is a pure registration utility following the same pattern as `Cron_Manager` and `Ability_Manager`:

- `register_page(object $page)` — accumulates admin page instances
- `register_cleanup_handler(callable $handler)` — stores the cleanup form callback
- `register_asset_enqueuer(callable $enqueuer)` — stores the asset enqueue callback
- `init()` — calls `init()` on each page and wires the registered callbacks to WP actions

All wiring logic (which pages to instantiate, what the cleanup handler does, which hooks to enqueue on) lives in `Sybgo::init_admin()` as closures. `Admin_Manager` has no knowledge of `Factory`, `Dashboard_Widget`, or any concrete page class.

`class-sybgo.php` now delegates all admin bootstrapping to `init_admin()`, which creates the manager, registers everything, and calls `init()`.

See [wp-plugin/docs/development.md](wp-plugin/docs/development.md) for updated constructor dependencies and project structure.

### New dependencies

None.

### Risks

None identified. Pure extraction — no logic change. All closures were previously inline in `class-sybgo.php`; they now live in `Sybgo::init_admin()`.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

None.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)