### PR TITLE
chore: improve QA agents — accessibility-first selectors and deeper assertions

### DIFF
--- a/.claude/agents/e2e-qa-tester.md
+++ b/.claude/agents/e2e-qa-tester.md
@@ -60,6 +60,39 @@ Once a flow is green manually, write a deterministic spec under `tests/e2e/<feat
 - **Auth:** assert field values with `toHaveValue()` before clicking submit; handle the WordPress email verification form if it appears; verify login success by URL, not just by absence of errors; always include the actual page URL in assertion error messages.
 - Fixture data goes in `tests/e2e/fixtures/`.
 
+### Selector strategy — accessibility-first
+
+Follow the [Playwright locator priority guide](https://playwright.dev/docs/locators#quick-guide). Use semantic locators in this order:
+
+1. `getByRole()` — matches ARIA role and accessible name. Most stable, directly tests what screen readers expose.
+2. `getByLabel()` — for form inputs. Matches the associated `<label>` text.
+3. `getByText()` — for visible text content when a role alone is not unique enough.
+4. `getByPlaceholder()`, `getByAltText()`, `getByTitle()` — context-specific alternatives.
+5. `getByTestId()` (`data-testid`) — only when no semantic locator applies and the element has no accessibility exposure worth adding.
+6. CSS selectors (`.class`, `#id`) and XPath — **do not use**. These break on UI changes and add nothing to accessibility coverage.
+
+**Chaining for precision:** when a role or text is not unique on the page, chain with `.filter()`:
+```ts
+// Avoid fragile nth-child selectors. Use filtering instead:
+page.getByRole('row').filter({ hasText: 'ACTIVE' }).getByRole('link', { name: 'View' })
+```
+
+**When accessibility attributes are missing:** if an element you need to target has no `aria-label`, accessible role, or associated label, add them to the plugin code first, then write the selector against the new attribute. This improves A11y for real users, not just test stability. Commit the attribute additions alongside the test in the same PR.
+
+Example — adding an `aria-label` to an icon-only button in a PHP template:
+```php
+printf(
+    '<button aria-label="%s" class="sybgo-action-btn">…</button>',
+    esc_attr__( 'View report', 'sybgo' )
+);
+```
+```ts
+// Test selector:
+page.getByRole('button', { name: 'View report' })
+```
+
+The IDs in the "Known sybgo flows" section below are orientation landmarks, not selector recipes. Prefer the semantic equivalent whenever one exists. For example, `getByRole('button', { name: 'Generate AI summary' })` beats `locator('#sybgo-generate-ai-btn')`.
+
 ## Known sybgo flows (memorize these)
 
 Use these as a reference when navigating or writing selectors. Verify each against the current code before depending on it — they may drift.
@@ -69,7 +102,7 @@ Use these as a reference when navigating or writing selectors. Verify each again
   - Top-level entry: `admin.php?page=sybgo-reports`
   - Settings entry: `options-general.php?page=sybgo-settings`
 - **Reports list:** columns in order are **Period / Events / Status / Created / Actions**. Status badges render as **ACTIVE**, **FROZEN**, or **SENT**.
-- **Report detail URL pattern:** `admin.php?page=sybgo-reports&view=details&report_id=<N>&_wpnonce=<X>`. The `_wpnonce` is **required** — the page calls `check_admin_referer('sybgo_view_report')` and dies on a bad/missing nonce. When Òwriting tests, navigate via clicking the row in the list (which carries the nonce) rather than constructing the URL.
+- **Report detail URL pattern:** `admin.php?page=sybgo-reports&view=details&report_id=<N>&_wpnonce=<X>`. The `_wpnonce` is **required** — the page calls `check_admin_referer('sybgo_view_report')` and dies on a bad/missing nonce. When writing tests, navigate via clicking the row in the list (which carries the nonce) rather than constructing the URL.
 - **AI Summary button:** id `sybgo-generate-ai-btn`. Disabled when WordPress version < 7, with the tooltip "AI summaries require WordPress 7".
 
 Additional features and flows are documented in the documentation under `site/docs/` and `wp-plugin/docs/`.
@@ -87,6 +120,6 @@ End with **READY TO MERGE** or a blocker list.
 
 ## Constraints
 
-- ✅ **Always do:** read the PR's "How to test" before touching the browser; read `wp-plugin/docs/E2E_TESTING.md` before writing new tests; take screenshots at each checkpoint; re-seed when state matters; write POM-based, deterministic tests.
+- ✅ **Always do:** read the PR's "How to test" before touching the browser; read `wp-plugin/docs/E2E_TESTING.md` before writing new tests; take screenshots at each checkpoint; re-seed when state matters; write POM-based, deterministic tests; use accessibility-first selectors; add missing `aria-label` / `role` attributes to plugin code when no semantic selector exists.
 - ⚠️ **Ask first:** if `bin/dev-up.sh` or `bin/dev-seed.sh` is missing; if a "How to test" step is ambiguous; if a flow requires data you cannot seed deterministically.
-- 🚫 **Never do:** modify plugin code under `wp-plugin/` or `lib/` (you test, you do not fix); use `setTimeout` / `waitForTimeout` in tests; assert on volatile values (timestamps, auto-increment IDs) without normalization; report PASS without screenshot or log evidence.
+- 🚫 **Never do:** modify plugin logic under `wp-plugin/` or `lib/` (you test, you do not fix — adding accessibility attributes to templates is the one allowed exception); use `setTimeout` / `waitForTimeout` in tests; assert on volatile values (timestamps, auto-increment IDs) without normalization; report PASS without screenshot or log evidence; use CSS class or ID selectors when a semantic Playwright locator is available.

--- a/.claude/agents/e2e-qa-tester.md
+++ b/.claude/agents/e2e-qa-tester.md
@@ -66,10 +66,13 @@ Follow the [Playwright locator priority guide](https://playwright.dev/docs/locat
 
 1. `getByRole()` — matches ARIA role and accessible name. Most stable, directly tests what screen readers expose.
 2. `getByLabel()` — for form inputs. Matches the associated `<label>` text.
-3. `getByText()` — for visible text content when a role alone is not unique enough.
-4. `getByPlaceholder()`, `getByAltText()`, `getByTitle()` — context-specific alternatives.
-5. `getByTestId()` (`data-testid`) — only when no semantic locator applies and the element has no accessibility exposure worth adding.
-6. CSS selectors (`.class`, `#id`) and XPath — **do not use**. These break on UI changes and add nothing to accessibility coverage.
+3. `getByPlaceholder()` — for inputs without a visible label.
+4. `getByAltText()` — for images.
+5. `getByTitle()` — for elements with a title attribute.
+6. `getByText()` — use with `{ exact: true }` for precision. Combine with `.filter()` when not unique on the page. You can also use `.first()` to match the first visible element, but only when the first match is reliably the intended element, not just to resolve ambiguity.
+7. `getByTestId()` (`data-testid`) — last resort only. If the element has no accessibility exposure, add `aria-label` to the plugin code first instead.
+8. `#id`, `.class` — avoid where possible. Use only when no semantic locator applies and the markup cannot be modified. Prefer stable, specific selectors over generic class names.
+9. XPath — do not use. Brittle and hard to maintain.
 
 **Chaining for precision:** when a role or text is not unique on the page, chain with `.filter()`:
 ```ts
@@ -122,4 +125,4 @@ End with **READY TO MERGE** or a blocker list.
 
 - ✅ **Always do:** read the PR's "How to test" before touching the browser; read `wp-plugin/docs/E2E_TESTING.md` before writing new tests; take screenshots at each checkpoint; re-seed when state matters; write POM-based, deterministic tests; use accessibility-first selectors; add missing `aria-label` / `role` attributes to plugin code when no semantic selector exists.
 - ⚠️ **Ask first:** if `bin/dev-up.sh` or `bin/dev-seed.sh` is missing; if a "How to test" step is ambiguous; if a flow requires data you cannot seed deterministically.
-- 🚫 **Never do:** modify plugin logic under `wp-plugin/` or `lib/` (you test, you do not fix — adding accessibility attributes to templates is the one allowed exception); use `setTimeout` / `waitForTimeout` in tests; assert on volatile values (timestamps, auto-increment IDs) without normalization; report PASS without screenshot or log evidence; use CSS class or ID selectors when a semantic Playwright locator is available.
+- 🚫 **Never do:** modify plugin logic under `wp-plugin/` or `lib/` (you test, you do not fix — adding accessibility attributes to templates is the one allowed exception); use `setTimeout` / `waitForTimeout` in tests; assert on volatile values (timestamps, auto-increment IDs) without normalization; report PASS without screenshot or log evidence; use XPath selectors; prefer CSS class or ID selectors over a semantic Playwright locator when one is available.

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -180,6 +180,6 @@ If blocked: list each blocker with a suggested fix.
 
 ## Boundaries
 
-- ✅ **Always do:** read ticket spec before testing, read full changed files (not just the diff), map every acceptance criterion to a test result, use Playwright MCP when browser testing is needed, provide concrete evidence for every result
+- ✅ **Always do:** read ticket spec before testing, read full changed files (not just the diff), map every acceptance criterion to a test result, use Playwright MCP when browser testing is needed, provide concrete evidence for every result; verify actual resulting state (DB value, rendered content, API response body) — not just that the action completed without an error
 - ⚠️ **Ask first:** if no ticket spec or acceptance criteria are available (ask before testing); if the local server is unreachable (report as a blocker and confirm whether to proceed with analysis only)
-- 🚫 **Never do:** modify any code or files, skip acceptance criteria without noting them, report PASS without evidence, conflate "no test failures" with "acceptance criteria met"
+- 🚫 **Never do:** modify any code or files, skip acceptance criteria without noting them, report PASS without evidence, conflate "no test failures" with "acceptance criteria met", accept a green test that only checks a page loaded or an element is visible when the criterion requires verifying data or behavior


### PR DESCRIPTION
# Description

Fixes:
- _No issue linked — direct improvement to agent definitions following external QA expert feedback._

Improves the two QA agents based on feedback from experienced WP plugin QA engineers. The `e2e-qa-tester` agent now writes more stable, accessible tests by default. The `qa-engineer` agent now enforces assertion depth rather than only prohibiting shallow ones.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

These are agent definition files — there is no runtime to execute. Validation is by review: the instructions were checked for correctness and internal consistency. The selector priority order was verified against the [official Playwright locator guide](https://playwright.dev/docs/locators#quick-guide).

### How to test

1. Review `.claude/agents/e2e-qa-tester.md` — confirm the new "Selector strategy — accessibility-first" section is present after the test-writing bullet list in Step 4.
2. Check the priority order matches Playwright's recommended order: `getByRole` → `getByLabel` → `getByText` → `getByPlaceholder/Alt/Title` → `getByTestId` → CSS/XPath (never).
3. Confirm the "When accessibility attributes are missing" block instructs the agent to add attributes to the plugin PHP templates and commit them alongside the test.
4. Confirm the Constraints section includes "use accessibility-first selectors" and "add missing aria-label/role attributes" in ✅ Always do, and bans CSS/ID selectors in 🚫 Never do.
5. Review `.claude/agents/qa-engineer.md` — confirm the ✅ Always do boundary now includes "verify actual resulting state (DB value, rendered content, API response body)".
6. Confirm the 🚫 Never do boundary now explicitly bans accepting a green test that only checks page load or element visibility when the criterion requires verifying data or behavior.

### Affected Features & Quality Assurance Scope

Agent definition files only (`.claude/agents/`). No plugin code, tests, or runtime logic is affected.

## Technical description

### Documentation

**`e2e-qa-tester.md` — accessibility-first selector strategy**

A new subsection "Selector strategy — accessibility-first" was added inside Step 4. It defines a strict priority order for Playwright locators, documents `.filter()` chaining for disambiguation, and instructs the agent to add missing `aria-label` / `role` attributes to PHP templates when no semantic selector exists — committing the attribute change alongside the test. This turns a test-infrastructure need into a real accessibility improvement.

The Constraints section was updated to surface both rules in the summary. The "Known sybgo flows" section now clarifies that documented DOM IDs are orientation landmarks, not selector recipes.

**`qa-engineer.md` — assertion depth**

Two targeted additions to the Boundaries section:
- ✅ Always do now requires verifying *actual resulting state* (DB value, rendered content, API response body), not just that an action completed without error.
- 🚫 Never do now explicitly names the failure pattern: accepting a green test that only checks page load or element visibility when the criterion requires verifying data or behavior.

### New dependencies

None.

### Risks

None identified. These are agent instruction files — the worst outcome of a mistake is suboptimal agent behavior, not a runtime failure.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

- **Built-in tests**: Agent definition files are plain markdown — no test harness is applicable. Correctness is validated by review against the Playwright documentation and the feedback that motivated the change.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)