### PR TITLE
feat(event-module): implement Event_Module::boot()

### DIFF
--- a/wp-plugin/Tests/Unit/Modules/EventModuleTest.php
+++ b/wp-plugin/Tests/Unit/Modules/EventModuleTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Event Module Unit Tests.
+ *
+ * @package Sybgo\Tests\Unit\Modules
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit\Modules;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Ability_Manager;
+use Sybgo\Database\Aggregated_Event_Repository;
+use Sybgo\Database\Event_Repository;
+use Sybgo\Events\Event_Tracker;
+use Sybgo\Factory;
+use Sybgo\Modules\Event_Module;
+
+/**
+ * Unit tests for Event_Module.
+ */
+class EventModuleTest extends TestCase {
+
+	/**
+	 * @var Factory&\Mockery\MockInterface
+	 */
+	private $factory;
+
+	/**
+	 * @var Ability_Manager&\Mockery\MockInterface
+	 */
+	private $abilities;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->factory   = Mockery::mock( Factory::class );
+		$this->abilities = Mockery::mock( Ability_Manager::class );
+
+		Functions\when( '__' )->returnArg();
+		Functions\when( 'current_user_can' )->justReturn( true );
+		// sybgo_init_api() is a real function loaded via the lib autoloader;
+		// Patchwork cannot intercept it. Let it run — its only side-effect is
+		// setting the $sybgo_api_event_repo global, which we verify directly.
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Build a module with shared mock infrastructure pre-wired.
+	 *
+	 * Sets up Factory to return mocked repositories and expects set_event_tracker().
+	 *
+	 * @param Event_Repository|null            $event_repo      Optional: specific repo mock to use.
+	 * @param Aggregated_Event_Repository|null $aggregated_repo Optional: specific aggregated repo mock.
+	 * @return array{module: Event_Module, event_repo: Event_Repository}
+	 */
+	private function build_module( $event_repo = null, $aggregated_repo = null ): array {
+		$event_repo      = $event_repo      ?? Mockery::mock( Event_Repository::class );
+		$aggregated_repo = $aggregated_repo ?? Mockery::mock( Aggregated_Event_Repository::class );
+
+		$this->factory->shouldReceive( 'create_event_repository' )->andReturn( $event_repo );
+		$this->factory->shouldReceive( 'create_aggregated_event_repository' )->andReturn( $aggregated_repo );
+		$this->factory->shouldReceive( 'set_event_tracker' )->once()->with( Mockery::type( Event_Tracker::class ) );
+		$this->abilities->shouldReceive( 'register' )->byDefault();
+
+		return array(
+			'module'     => new Event_Module( $this->factory, $this->abilities ),
+			'event_repo' => $event_repo,
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// boot — event tracking initialisation
+	// -------------------------------------------------------------------------
+
+	/**
+	 * boot() creates an Event_Tracker and stores it on the factory.
+	 *
+	 * @return void
+	 */
+	public function test_boot_stores_event_tracker_on_factory(): void {
+		[  'module' => $module ] = $this->build_module();
+		$module->boot();
+
+		// Assertion is satisfied by the ->once() expectation on set_event_tracker above.
+		$this->assertTrue( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// boot — public extensibility API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * boot() calls sybgo_init_api() — verified via global side-effect.
+	 *
+	 * sybgo_init_api() sets $sybgo_api_event_repo globally; we check that.
+	 *
+	 * @return void
+	 */
+	public function test_boot_exposes_extensibility_api(): void {
+		[  'module' => $module, 'event_repo' => $event_repo ] = $this->build_module();
+		$module->boot();
+
+		global $sybgo_api_event_repo;
+		$this->assertSame( $event_repo, $sybgo_api_event_repo );
+	}
+
+	// -------------------------------------------------------------------------
+	// boot — ability registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * boot() schedules sybgo/track-events ability registration on 'init' at priority 5.
+	 *
+	 * @return void
+	 */
+	public function test_boot_registers_track_events_on_init_hook_priority_5(): void {
+		[  'module' => $module ] = $this->build_module();
+
+		Actions\expectAdded( 'init' )->once()->with( Mockery::type( 'Closure' ), 5, Mockery::any() );
+
+		$module->boot();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * The deferred init callback calls Ability_Manager::register() for 'sybgo/track-events'.
+	 *
+	 * @return void
+	 */
+	public function test_deferred_callback_registers_track_events_ability(): void {
+		$captured_callback = null;
+
+		Actions\expectAdded( 'init' )->once()->whenHappen(
+			function ( $callback ) use ( &$captured_callback ): void {
+				$captured_callback = $callback;
+			}
+		);
+
+		$this->abilities
+			->shouldReceive( 'register' )
+			->once()
+			->with(
+				'sybgo/track-events',
+				Mockery::on(
+					function ( array $args ): bool {
+						return 'sybgo' === ( $args['category'] ?? '' )
+							&& isset( $args['execute_callback'] )
+							&& isset( $args['permission_callback'] );
+					}
+				)
+			);
+
+		[  'module' => $module ] = $this->build_module();
+		$module->boot();
+
+		$this->assertNotNull( $captured_callback );
+		( $captured_callback )();
+	}
+}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -137,10 +137,20 @@ class Sybgo {
 			$module->boot();
 		}
 
-		// Legacy init_*() sub-methods keep existing behaviour until each
-		// module's boot() is fully implemented (sub-issues #95–#99).
+		// Defer Ability_Manager::init() to the 'init' action at priority 20
+		// so that module boot() callbacks (which register abilities at priority 5
+		// on 'init') have already run before the manager wires them into WP.
+		add_action(
+			'init',
+			static function () use ( $abilities ): void {
+				$abilities->init();
+			},
+			20
+		);
+
+		// Legacy init_*() sub-methods keep remaining behaviour until each
+		// module's boot() is fully implemented (sub-issues #96–#99).
 		// They are removed in sub-issue #100 once all modules are complete.
-		$this->init_event_tracking();
 		$this->init_abilities();
 		if ( is_admin() ) {
 			$this->init_admin();
@@ -174,15 +184,16 @@ class Sybgo {
 	}
 
 	/**
-	 * Initialise the public extensibility API and register WordPress 7 abilities.
+	 * Register the sybgo/generate-summary WordPress 7 Ability.
+	 *
+	 * The sybgo_init_api() call and the sybgo/track-events ability have been
+	 * moved to Event_Module::boot() (sub-issue #95). This method registers only
+	 * the generate-summary ability and will be emptied once AI_Module::boot()
+	 * is implemented in sub-issue #98.
 	 *
 	 * @return void
 	 */
 	private function init_abilities(): void {
-		// Initialise the public API so third-party plugins can track events.
-		$event_repo = $this->factory->create_event_repository();
-		\sybgo_init_api( $event_repo );
-
 		// Guard: ability registration must only run on WordPress 7+.
 		// On earlier versions wp_register_ability is undefined.
 		if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -223,40 +234,9 @@ class Sybgo {
 					)
 				);
 
-				$ability_manager->register(
-					'sybgo/track-events',
-					array(
-						'label'               => __( 'Track Site Events', 'sybgo' ),
-						'description'         => __( 'Records WordPress site events for inclusion in the weekly digest.', 'sybgo' ),
-						'category'            => 'sybgo',
-						'execute_callback'    => static function () use ( $factory ): bool {
-							return null !== $factory->get_event_tracker();
-						},
-						'permission_callback' => static function (): bool {
-							return current_user_can( 'manage_options' );
-						},
-					)
-				);
-
 				$ability_manager->init();
 			}
 		);
-	}
-
-	/**
-	 * Initialize event tracking system.
-	 *
-	 * @return void
-	 */
-	private function init_event_tracking(): void {
-		// Initialize event tracker.
-		$event_repo      = $this->factory->create_event_repository();
-		$aggregated_repo = $this->factory->create_aggregated_event_repository();
-		$event_tracker   = new Events\Event_Tracker( $event_repo, $aggregated_repo );
-		$event_tracker->init();
-
-		// Store in factory for later use.
-		$this->factory->set_event_tracker( $event_tracker );
 	}
 
 	/**

--- a/wp-plugin/modules/class-event-module.php
+++ b/wp-plugin/modules/class-event-module.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Sybgo\Modules;
 
 use Sybgo\Ability_Manager;
+use Sybgo\Events\Event_Tracker;
 use Sybgo\Factory;
 
 // Exit if accessed directly.
@@ -36,7 +37,6 @@ class Event_Module implements Module_Interface {
 	 * Factory instance.
 	 *
 	 * @var Factory
-	 * @phpstan-ignore property.onlyWritten (used once boot() is implemented in sub-issue #95)
 	 */
 	private Factory $factory;
 
@@ -44,7 +44,6 @@ class Event_Module implements Module_Interface {
 	 * Ability Manager instance.
 	 *
 	 * @var Ability_Manager
-	 * @phpstan-ignore property.onlyWritten (used once boot() is implemented in sub-issue #95)
 	 */
 	private Ability_Manager $abilities;
 
@@ -60,11 +59,50 @@ class Event_Module implements Module_Interface {
 	}
 
 	/**
-	 * Register event-tracking hooks and abilities.
+	 * Register event-tracking hooks and the sybgo/track-events ability.
+	 *
+	 * Initialises Event_Tracker, stores it on the factory, exposes the public
+	 * extensibility API via sybgo_init_api(), and schedules ability registration
+	 * for priority 5 on the 'init' action so that __() evaluates after the
+	 * text domain is loaded (WP 6.7+ fires _doing_it_wrong() otherwise).
 	 *
 	 * @return void
 	 */
 	public function boot(): void {
-		// No-op stub — implementation follows in a dedicated sub-issue.
+		$event_repo      = $this->factory->create_event_repository();
+		$aggregated_repo = $this->factory->create_aggregated_event_repository();
+		$event_tracker   = new Event_Tracker( $event_repo, $aggregated_repo );
+		$event_tracker->init();
+		$this->factory->set_event_tracker( $event_tracker );
+
+		// Expose the public extensibility API.
+		\sybgo_init_api( $event_repo );
+
+		// Defer ability registration to 'init' so __() evaluates after the
+		// 'sybgo' text domain is loaded. Priority 5 ensures this runs before
+		// Ability_Manager::init() which is scheduled at priority 20.
+		$abilities = $this->abilities;
+		$factory   = $this->factory;
+
+		add_action(
+			'init',
+			static function () use ( $abilities, $factory ): void {
+				$abilities->register(
+					'sybgo/track-events',
+					array(
+						'label'               => __( 'Track Site Events', 'sybgo' ),
+						'description'         => __( 'Records WordPress site events for inclusion in the weekly digest.', 'sybgo' ),
+						'category'            => 'sybgo',
+						'execute_callback'    => static function () use ( $factory ): bool {
+							return null !== $factory->get_event_tracker();
+						},
+						'permission_callback' => static function (): bool {
+							return current_user_can( 'manage_options' );
+						},
+					)
+				);
+			},
+			5
+		);
 	}
 }


### PR DESCRIPTION
# Description

Moves event tracking initialisation, the public extensibility API call, and the \`sybgo/track-events\` Ability registration out of \`Sybgo::init_event_tracking()\` and \`init_abilities()\` into \`Event_Module::boot()\`, making the event-domain wiring independently testable as a named method.

Closes #95

## Type of change

- [x] Sub-task of #93
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Behaviour is identical to develop — the same hooks, API, and ability are registered; only the location of that wiring changed. Manual verification on a local wp-env install:

1. Activated the plugin — no fatal errors, all admin pages loaded normally.
2. Ran `wp cron event list | grep sybgo` — all four cron events present and scheduled as before.
3. Ran `wp cron event run sybgo_freeze_weekly_report` — weekly report frozen successfully; event tracking continued writing rows to `wp_sybgo_events` before and after the freeze.
4. Navigated to WP Admin → Dashboard — widget showed current-week event counts, confirming Event_Tracker is still active.

### How to test

1. Check out `feat/event-module-95` and run `composer dump-autoload` inside `wp-plugin/`.
2. Boot wp-env: `cd tests/e2e && npx wp-env start`.
3. Run unit tests: `cd wp-plugin && vendor/bin/phpunit --testsuite=Unit` — 4 new EventModuleTest tests pass; 5 pre-existing DashboardWidgetTest errors (unrelated, present on develop too).
4. Publish a post via WP Admin or `wp post create --post_title="Test" --post_status=publish`.
5. Verify the event was tracked: `wp db query "SELECT event_type FROM wp_sybgo_events ORDER BY id DESC LIMIT 1"` — should show `post_published`.
6. Run `wp cron event run sybgo_freeze_weekly_report` and confirm the report freezes without PHP errors in the debug log.

### Affected Features & Quality Assurance Scope

Event tracking, the public extensibility API (`sybgo_init_api`), and the `sybgo/track-events` Ability are affected — behaviour unchanged but wired from a new location. All other plugin features are untouched.

## Technical description

`Event_Module::boot()` now:

1. Calls `Factory::create_event_repository()` and `create_aggregated_event_repository()`, constructs `Event_Tracker`, calls `init()` on it, and stores it via `Factory::set_event_tracker()`.
2. Calls `sybgo_init_api($event_repo)` to expose the public extension API.
3. Schedules a closure on `add_action('init', …, 5)` that calls `Ability_Manager::register('sybgo/track-events', …)` with the translated label and description. Priority 5 ensures registration runs before `Ability_Manager::init()`, which is now deferred to `add_action('init', …, 20)` inside `Sybgo::init()`.

The `init` action deferral preserves the fix for the WP 6.7+ textdomain early-loading bug: calling `__()` during `plugins_loaded` before the text domain is loaded triggers `_doing_it_wrong()` → `trigger_error()` → captured by Error_Tracker, polluting aggregated event counts.

`Sybgo::init_event_tracking()` is deleted (dead code after extraction). `init_abilities()` now only handles `sybgo/generate-summary`, which will move to `AI_Module` in #98.

See [wp-plugin/docs/development.md](../wp-plugin/docs/development.md) — Feature Module Architecture section.

### New dependencies

None.

### Risks

None identified. The ability registration timing (priority 5 → priority 20 on `init`) is the only subtle change; it preserves the existing WP7 deferral fix and is covered by `EventModuleTest::test_boot_registers_track_events_on_init_hook_priority_5`.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

None.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)