### PR TITLE
feat(report-module): implement Report_Module — widget, reports page, freeze cron

### DIFF
--- a/wp-plugin/Tests/Unit/Modules/ReportModuleTest.php
+++ b/wp-plugin/Tests/Unit/Modules/ReportModuleTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Report Module Unit Tests.
+ *
+ * @package Sybgo\Tests\Unit\Modules
+ */
+
+declare(strict_types=1);
+
+namespace Sybgo\Tests\Unit\Modules;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sybgo\Admin\Admin_Manager;
+use Sybgo\Admin\Dashboard_Widget;
+use Sybgo\Admin\Reports_Page;
+use Sybgo\Cron_Manager;
+use Sybgo\Database\Aggregated_Event_Repository;
+use Sybgo\Database\Event_Repository;
+use Sybgo\Database\Report_Repository;
+use Sybgo\Email\Email_Manager;
+use Sybgo\Events\Event_Registry;
+use Sybgo\Factory;
+use Sybgo\Modules\Report_Module;
+use Sybgo\Reports\Report_Manager;
+
+/**
+ * Unit tests for Report_Module.
+ */
+class ReportModuleTest extends TestCase {
+
+	/**
+	 * @var Factory&\Mockery\MockInterface
+	 */
+	private $factory;
+
+	/**
+	 * @var Cron_Manager&\Mockery\MockInterface
+	 */
+	private $cron;
+
+	/**
+	 * @var Admin_Manager&\Mockery\MockInterface
+	 */
+	private $admin;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->factory = Mockery::mock( Factory::class );
+		$this->cron    = Mockery::mock( Cron_Manager::class );
+		$this->admin   = Mockery::mock( Admin_Manager::class );
+
+		// Stub WordPress functions used by factory calls.
+		Functions\when( 'esc_html__' )->returnArg();
+		Functions\when( '__' )->returnArg();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Wire the factory mock to return typed repository mocks.
+	 *
+	 * @return void
+	 */
+	private function wire_factory(): void {
+		$this->factory->shouldReceive( 'create_event_repository' )
+			->andReturn( Mockery::mock( Event_Repository::class ) );
+		$this->factory->shouldReceive( 'create_report_repository' )
+			->andReturn( Mockery::mock( Report_Repository::class ) );
+		$this->factory->shouldReceive( 'create_event_registry' )
+			->andReturn( Mockery::mock( Event_Registry::class ) );
+		$this->factory->shouldReceive( 'create_ai_summarizer' )
+			->andReturn( null );
+		$this->factory->shouldReceive( 'create_aggregated_event_repository' )
+			->andReturn( Mockery::mock( Aggregated_Event_Repository::class ) );
+		$this->factory->shouldReceive( 'create_report_manager' )
+			->andReturn( Mockery::mock( Report_Manager::class ) );
+		$this->factory->shouldReceive( 'create_email_manager' )
+			->andReturn( Mockery::mock( Email_Manager::class ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// boot — admin page registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * boot() registers Dashboard_Widget and Reports_Page with Admin_Manager.
+	 *
+	 * @return void
+	 */
+	public function test_boot_registers_dashboard_widget_and_reports_page(): void {
+		$this->wire_factory();
+
+		$this->admin
+			->shouldReceive( 'register_page' )
+			->twice()
+			->with(
+				Mockery::on(
+					function ( object $page ): bool {
+						return $page instanceof Dashboard_Widget || $page instanceof Reports_Page;
+					}
+				)
+			);
+
+		$this->cron->shouldReceive( 'register' )->once();
+
+		$module = new Report_Module( $this->factory, $this->cron, $this->admin );
+		$module->boot();
+
+		$this->assertTrue( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// boot — cron registration
+	// -------------------------------------------------------------------------
+
+	/**
+	 * boot() registers the sybgo_freeze_weekly_report cron hook.
+	 *
+	 * @return void
+	 */
+	public function test_boot_registers_freeze_cron(): void {
+		$this->wire_factory();
+		$this->admin->shouldReceive( 'register_page' )->twice();
+
+		$this->cron
+			->shouldReceive( 'register' )
+			->once()
+			->with(
+				'sybgo_freeze_weekly_report',
+				'weekly',
+				Mockery::type( 'array' ),
+				'next Sunday 23:55'
+			);
+
+		$module = new Report_Module( $this->factory, $this->cron, $this->admin );
+		$module->boot();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * boot() wires the freeze cron callback to Report_Module::freeze_report_callback().
+	 *
+	 * @return void
+	 */
+	public function test_boot_freeze_cron_callback_points_to_module_method(): void {
+		$this->wire_factory();
+		$this->admin->shouldReceive( 'register_page' )->twice();
+
+		$captured_callback = null;
+		$this->cron
+			->shouldReceive( 'register' )
+			->once()
+			->andReturnUsing(
+				function ( string $hook, string $schedule, callable $callback ) use ( &$captured_callback ): void {
+					$captured_callback = $callback;
+				}
+			);
+
+		$module = new Report_Module( $this->factory, $this->cron, $this->admin );
+		$module->boot();
+
+		$this->assertIsArray( $captured_callback );
+		$this->assertSame( $module, $captured_callback[0] );
+		$this->assertSame( 'freeze_report_callback', $captured_callback[1] );
+	}
+
+	// -------------------------------------------------------------------------
+	// freeze_report_callback
+	// -------------------------------------------------------------------------
+
+	/**
+	 * freeze_report_callback() calls freeze_current_report() and logs success.
+	 *
+	 * @return void
+	 */
+	public function test_freeze_callback_invokes_report_manager_when_report_exists(): void {
+		$report_manager = Mockery::mock( Report_Manager::class );
+		$report_manager->shouldReceive( 'freeze_current_report' )->once()->andReturn( 42 );
+
+		$this->factory->shouldReceive( 'create_report_manager' )->andReturn( $report_manager );
+
+		$module = new Report_Module( $this->factory, $this->cron, $this->admin );
+		$module->freeze_report_callback();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * freeze_report_callback() handles the case where no active report exists.
+	 *
+	 * @return void
+	 */
+	public function test_freeze_callback_handles_no_active_report(): void {
+		$report_manager = Mockery::mock( Report_Manager::class );
+		$report_manager->shouldReceive( 'freeze_current_report' )->once()->andReturn( null );
+
+		$this->factory->shouldReceive( 'create_report_manager' )->andReturn( $report_manager );
+
+		$module = new Report_Module( $this->factory, $this->cron, $this->admin );
+		$module->freeze_report_callback();
+
+		$this->assertTrue( true );
+	}
+}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -148,8 +148,18 @@ class Sybgo {
 			20
 		);
 
+		// Initialise the shared Cron_Manager so that Report_Module's registered
+		// cron callbacks (e.g. sybgo_freeze_weekly_report) are actually scheduled.
+		$cron->init();
+
+		// Initialise the shared Admin_Manager so that Report_Module's registered
+		// admin pages (Dashboard_Widget, Reports_Page) are actually wired up.
+		if ( is_admin() ) {
+			$admin->init();
+		}
+
 		// Legacy init_*() sub-methods keep remaining behaviour until each
-		// module's boot() is fully implemented (sub-issues #96–#99).
+		// module's boot() is fully implemented (sub-issues #97–#99).
 		// They are removed in sub-issue #100 once all modules are complete.
 		$this->init_abilities();
 		if ( is_admin() ) {

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -247,9 +247,8 @@ class Sybgo {
 	private function init_admin(): void {
 		$admin_manager = new Admin\Admin_Manager();
 
-		$admin_manager->register_page( $this->create_dashboard_widget() );
+		// Dashboard_Widget and Reports_Page are now registered by Report_Module::boot().
 		$admin_manager->register_page( $this->create_settings_page() );
-		$admin_manager->register_page( $this->create_reports_page() );
 
 		$factory = $this->factory;
 
@@ -326,29 +325,6 @@ class Sybgo {
 	}
 
 	/**
-	 * Create dashboard widget instance.
-	 *
-	 * @return Admin\Dashboard_Widget Dashboard widget instance.
-	 */
-	private function create_dashboard_widget(): Admin\Dashboard_Widget {
-		$event_repo       = $this->factory->create_event_repository();
-		$report_repo      = $this->factory->create_report_repository();
-		$event_registry   = $this->factory->create_event_registry();
-		$ai_summarizer    = $this->factory->create_ai_summarizer();
-		$aggregated_repo  = $this->factory->create_aggregated_event_repository();
-		$report_generator = new Reports\Report_Generator( $event_repo, $report_repo );
-
-		return new Admin\Dashboard_Widget(
-			$event_repo,
-			$report_repo,
-			$report_generator,
-			$ai_summarizer,
-			$event_registry,
-			$aggregated_repo
-		);
-	}
-
-	/**
 	 * Create settings page instance.
 	 *
 	 * @return Admin\Settings_Page Settings page instance.
@@ -358,33 +334,6 @@ class Sybgo {
 		$db_stats       = $this->factory->create_db_stats();
 
 		return new Admin\Settings_Page( $event_registry, $db_stats );
-	}
-
-	/**
-	 * Create reports page instance.
-	 *
-	 * @return Admin\Reports_Page Reports page instance.
-	 */
-	private function create_reports_page(): Admin\Reports_Page {
-		$event_repo       = $this->factory->create_event_repository();
-		$report_repo      = $this->factory->create_report_repository();
-		$event_registry   = $this->factory->create_event_registry();
-		$report_manager   = $this->factory->create_report_manager();
-		$ai_summarizer    = $this->factory->create_ai_summarizer();
-		$report_generator = new Reports\Report_Generator( $event_repo, $report_repo );
-		$email_manager    = $this->factory->create_email_manager();
-		$aggregated_repo  = $this->factory->create_aggregated_event_repository();
-
-		return new Admin\Reports_Page(
-			$event_repo,
-			$report_repo,
-			$report_manager,
-			$report_generator,
-			$email_manager,
-			$event_registry,
-			$aggregated_repo,
-			$ai_summarizer
-		);
 	}
 
 	/**
@@ -416,11 +365,8 @@ class Sybgo {
 		// Register custom cron intervals.
 		add_filter( 'cron_schedules', array( $this, 'add_cron_intervals' ) );
 
-		// Schedule weekly freeze (Sunday 23:55).
-		if ( ! wp_next_scheduled( $hooks[0] ) ) {
-			$next_sunday = strtotime( 'next Sunday 23:55' );
-			wp_schedule_event( $next_sunday, 'weekly', $hooks[0] );
-		}
+		// sybgo_freeze_weekly_report is now registered by Report_Module::boot()
+		// via CronManager — scheduling and callback are handled there.
 
 		// Schedule weekly email (Monday 00:05).
 		if ( ! wp_next_scheduled( $hooks[1] ) ) {
@@ -440,27 +386,10 @@ class Sybgo {
 			wp_schedule_event( $next_9am, 'daily', $hooks[3] );
 		}
 
-		// Register cron callbacks.
-		add_action( $hooks[0], array( $this, 'freeze_weekly_report_callback' ) );
+		// Register remaining cron callbacks (freeze is handled by Report_Module).
 		add_action( $hooks[1], array( $this, 'send_report_emails_callback' ) );
 		add_action( $hooks[2], array( $this, 'cleanup_old_events_callback' ) );
 		add_action( $hooks[3], array( $this, 'retry_failed_emails_callback' ) );
-	}
-
-	/**
-	 * Cron callback: Freeze weekly report.
-	 *
-	 * @return void
-	 */
-	public function freeze_weekly_report_callback(): void {
-		$report_manager = $this->factory->create_report_manager();
-		$frozen_id      = $report_manager->freeze_current_report();
-
-		if ( $frozen_id ) {
-			Logger::info( sprintf( 'Weekly report #%d frozen successfully', $frozen_id ) );
-		} else {
-			Logger::info( 'No active report to freeze' );
-		}
 	}
 
 	/**

--- a/wp-plugin/modules/class-report-module.php
+++ b/wp-plugin/modules/class-report-module.php
@@ -15,8 +15,12 @@ declare(strict_types=1);
 namespace Sybgo\Modules;
 
 use Sybgo\Admin\Admin_Manager;
+use Sybgo\Admin\Dashboard_Widget;
+use Sybgo\Admin\Reports_Page;
 use Sybgo\Cron_Manager;
 use Sybgo\Factory;
+use Sybgo\Logger;
+use Sybgo\Reports\Report_Generator;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -37,7 +41,6 @@ class Report_Module implements Module_Interface {
 	 * Factory instance.
 	 *
 	 * @var Factory
-	 * @phpstan-ignore property.onlyWritten (used once boot() is implemented in sub-issue #96)
 	 */
 	private Factory $factory;
 
@@ -45,7 +48,6 @@ class Report_Module implements Module_Interface {
 	 * Cron Manager instance.
 	 *
 	 * @var Cron_Manager
-	 * @phpstan-ignore property.onlyWritten (used once boot() is implemented in sub-issue #96)
 	 */
 	private Cron_Manager $cron;
 
@@ -53,7 +55,6 @@ class Report_Module implements Module_Interface {
 	 * Admin Manager instance.
 	 *
 	 * @var Admin_Manager
-	 * @phpstan-ignore property.onlyWritten (used once boot() is implemented in sub-issue #96)
 	 */
 	private Admin_Manager $admin;
 
@@ -73,9 +74,91 @@ class Report_Module implements Module_Interface {
 	/**
 	 * Register reporting hooks, admin pages, and cron events.
 	 *
+	 * Registers Dashboard_Widget and Reports_Page with Admin_Manager, and
+	 * wires the sybgo_freeze_weekly_report cron hook to the named
+	 * freeze_report_callback() method so it is independently testable.
+	 *
 	 * @return void
 	 */
 	public function boot(): void {
-		// No-op stub — implementation follows in a dedicated sub-issue.
+		$this->admin->register_page( $this->build_dashboard_widget() );
+		$this->admin->register_page( $this->build_reports_page() );
+
+		$this->cron->register(
+			'sybgo_freeze_weekly_report',
+			'weekly',
+			array( $this, 'freeze_report_callback' ),
+			'next Sunday 23:55'
+		);
+	}
+
+	/**
+	 * Cron callback: freeze the current active report.
+	 *
+	 * Invoked by WP-Cron on the sybgo_freeze_weekly_report hook (weekly,
+	 * Sunday 23:55). Delegates to Report_Manager::freeze_current_report()
+	 * and logs the outcome.
+	 *
+	 * @return void
+	 */
+	public function freeze_report_callback(): void {
+		$report_manager = $this->factory->create_report_manager();
+		$frozen_id      = $report_manager->freeze_current_report();
+
+		if ( $frozen_id ) {
+			Logger::info( sprintf( 'Weekly report #%d frozen successfully', $frozen_id ) );
+		} else {
+			Logger::info( 'No active report to freeze' );
+		}
+	}
+
+	/**
+	 * Build the Dashboard_Widget instance with all required dependencies.
+	 *
+	 * @return Dashboard_Widget
+	 */
+	private function build_dashboard_widget(): Dashboard_Widget {
+		$event_repo       = $this->factory->create_event_repository();
+		$report_repo      = $this->factory->create_report_repository();
+		$event_registry   = $this->factory->create_event_registry();
+		$ai_summarizer    = $this->factory->create_ai_summarizer();
+		$aggregated_repo  = $this->factory->create_aggregated_event_repository();
+		$report_generator = new Report_Generator( $event_repo, $report_repo );
+
+		return new Dashboard_Widget(
+			$event_repo,
+			$report_repo,
+			$report_generator,
+			$ai_summarizer,
+			$event_registry,
+			$aggregated_repo
+		);
+	}
+
+	/**
+	 * Build the Reports_Page instance with all required dependencies.
+	 *
+	 * @return Reports_Page
+	 */
+	private function build_reports_page(): Reports_Page {
+		$event_repo       = $this->factory->create_event_repository();
+		$report_repo      = $this->factory->create_report_repository();
+		$event_registry   = $this->factory->create_event_registry();
+		$report_manager   = $this->factory->create_report_manager();
+		$ai_summarizer    = $this->factory->create_ai_summarizer();
+		$report_generator = new Report_Generator( $event_repo, $report_repo );
+		$email_manager    = $this->factory->create_email_manager();
+		$aggregated_repo  = $this->factory->create_aggregated_event_repository();
+
+		return new Reports_Page(
+			$event_repo,
+			$report_repo,
+			$report_manager,
+			$report_generator,
+			$email_manager,
+			$event_registry,
+			$aggregated_repo,
+			$ai_summarizer
+		);
 	}
 }


### PR DESCRIPTION
# Description

Moves Dashboard_Widget and Reports_Page registration and the \`sybgo_freeze_weekly_report\` cron callback from \`Sybgo\` into \`Report_Module::boot()\` and a new public named method \`freeze_report_callback()\`, making the freeze logic independently testable.

Closes #96

## Type of change

- [x] Sub-task of #93
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

1. Activated the plugin on a local wp-env install — no fatal errors; dashboard widget and reports page loaded correctly.
2. Navigated to WP Admin → Dashboard — widget displayed current-week event counts.
3. Navigated to WP Admin → Reports — reports list rendered with the active report row.
4. Ran `wp cron event run sybgo_freeze_weekly_report` — report froze successfully; confirmed in DB with `wp db query "SELECT status FROM wp_sybgo_reports ORDER BY id DESC LIMIT 1"` (showed `frozen`).

### How to test

1. Check out `feat/report-module-96` and run `composer dump-autoload` in `wp-plugin/`.
2. Boot wp-env: `cd tests/e2e && npx wp-env start`.
3. Run unit tests: `cd wp-plugin && vendor/bin/phpunit --testsuite=Unit` — 5 new ReportModuleTest tests pass.
4. Activate the plugin and navigate to WP Admin → Dashboard — widget should display.
5. Navigate to WP Admin → Reports — reports page should render.
6. Run `wp cron event run sybgo_freeze_weekly_report` — confirm the report is frozen in the DB.

### Affected Features & Quality Assurance Scope

Dashboard widget, reports page, and the weekly freeze cron are the affected features — behaviour is identical, only wiring location changed. All other plugin features unchanged.

## Technical description

`Report_Module::boot()` calls `Admin_Manager::register_page()` for both `Dashboard_Widget` and `Reports_Page` (built via private factory helpers that mirror the removed `create_*` methods from `Sybgo`). It calls `Cron_Manager::register('sybgo_freeze_weekly_report', 'weekly', [$this, 'freeze_report_callback'], 'next Sunday 23:55')`.

`freeze_report_callback()` is public and named, which allows `CronManager` to store `[$module, 'freeze_report_callback']` as a callable — this is what makes it unit-testable in isolation from `boot()`.

Removed from `class-sybgo.php`: `create_dashboard_widget()`, `create_reports_page()`, `freeze_weekly_report_callback()`, and the dashboard widget / reports page lines inside `init_admin()`. The freeze scheduling and callback registration inside `init_cron_schedules()` are also removed.

### New dependencies

None.

### Risks

None identified. Dashboard widget, reports page, and freeze cron behaviour are unchanged; only the class that wires them differs.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

None.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.)
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)