### PR TITLE
refactor(sybgo): trim Sybgo to 7 lifecycle methods — EPIC #93 complete

### DIFF
--- a/wp-plugin/Tests/Unit/Admin/UninstallerTest.php
+++ b/wp-plugin/Tests/Unit/Admin/UninstallerTest.php
@@ -11,8 +11,8 @@ namespace Sybgo\Tests\Unit\Admin;
 
 use Sybgo\Admin\Uninstaller;
 use Sybgo\Admin\Settings_Page;
+use Sybgo\Cron_Manager;
 use Sybgo\Database\DatabaseManager;
-use Sybgo\Sybgo;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Mockery;
@@ -89,7 +89,7 @@ class UninstallerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_clear_cron_hooks_clears_all_hooks(): void {
-		$hooks = Sybgo::get_cron_hooks();
+		$hooks = Cron_Manager::get_hooks();
 
 		Functions\expect( 'wp_clear_scheduled_hook' )
 			->times( count( $hooks ) )
@@ -127,7 +127,7 @@ class UninstallerTest extends TestCase {
 			->times( count( ( new DatabaseManager() )->get_table_names() ) );
 
 		Functions\expect( 'wp_clear_scheduled_hook' )
-			->times( count( Sybgo::get_cron_hooks() ) );
+			->times( count( Cron_Manager::get_hooks() ) );
 
 		Functions\expect( 'delete_option' )
 			->times( count( Settings_Page::get_option_names() ) );

--- a/wp-plugin/admin/class-uninstaller.php
+++ b/wp-plugin/admin/class-uninstaller.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Sybgo\Admin;
 
+use Sybgo\Cron_Manager;
 use Sybgo\Database\DatabaseManager;
-use Sybgo\Sybgo;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -58,12 +58,12 @@ class Uninstaller {
 	/**
 	 * Clear all plugin-registered cron hooks.
 	 *
-	 * Hook names are sourced from the Sybgo class to avoid duplication.
+	 * Hook names are sourced from Cron_Manager::get_hooks() as the canonical source.
 	 *
 	 * @return void
 	 */
 	public function clear_cron_hooks(): void {
-		foreach ( Sybgo::get_cron_hooks() as $hook ) {
+		foreach ( Cron_Manager::get_hooks() as $hook ) {
 			wp_clear_scheduled_hook( $hook );
 		}
 	}

--- a/wp-plugin/class-sybgo.php
+++ b/wp-plugin/class-sybgo.php
@@ -165,7 +165,8 @@ class Sybgo {
 	 * Build the list of feature modules.
 	 *
 	 * Each module receives only the deps it needs. The order determines boot()
-	 * call order; for the scaffold phase all boot() methods are no-ops.
+	 * call order; Event_Module must boot first so the Event_Tracker is available
+	 * before other modules may depend on it.
 	 *
 	 * @param Cron_Manager        $cron      Cron Manager instance.
 	 * @param Admin\Admin_Manager $admin     Admin Manager instance.
@@ -184,20 +185,6 @@ class Sybgo {
 			new Modules\AI_Module( $this->factory, $abilities ),
 			new Modules\Settings_Module( $this->factory, $cron, $admin ),
 		);
-	}
-
-	/**
-	 * Get all cron hook names registered by the plugin.
-	 *
-	 * Used by deactivate() and Uninstaller. Delegates to Cron_Manager::get_hooks()
-	 * as the canonical source. Kept here for the deactivation hook until sub-issue
-	 * #100 removes it.
-	 *
-	 * @return array<string> List of WP-Cron hook names.
-	 * @since 1.0.0
-	 */
-	public static function get_cron_hooks(): array {
-		return Cron_Manager::get_hooks();
 	}
 
 	/**
@@ -238,7 +225,7 @@ class Sybgo {
 	 */
 	public function deactivate(): void {
 		// Clear scheduled events.
-		foreach ( self::get_cron_hooks() as $hook ) {
+		foreach ( Cron_Manager::get_hooks() as $hook ) {
 			wp_clear_scheduled_hook( $hook );
 		}
 

--- a/wp-plugin/docs/development.md
+++ b/wp-plugin/docs/development.md
@@ -402,7 +402,7 @@ When a user deletes the plugin from the WordPress admin, WordPress calls `uninst
 `Uninstaller` performs three steps in order:
 
 1. **Drop database tables** — calls `DatabaseManager::get_table_names()` (static, no side effects) and issues `DROP TABLE IF EXISTS` for each table.
-2. **Clear cron events** — calls `Sybgo::get_cron_hooks()` and passes each hook to `wp_clear_scheduled_hook()`.
+2. **Clear cron events** — calls `Cron_Manager::get_hooks()` and passes each hook to `wp_clear_scheduled_hook()`.
 3. **Delete options** — calls `Settings_Page::get_option_names()` and passes each name to `delete_option()`.
 
 Each of those static methods is the single source of truth for its identifiers, so adding a new table, hook, or option to the appropriate method is enough to ensure it is also cleaned up on uninstall.


### PR DESCRIPTION
# Description

Removes `Sybgo::get_cron_hooks()` — the last non-lifecycle method on the class. `Uninstaller` and `deactivate()` now call `Cron_Manager::get_hooks()` directly as the canonical source. `Sybgo` is reduced to its target 7 methods: `get_instance`, `__construct`, `get_library_config`, `init`, `build_modules`, `activate`, `deactivate`. EPIC #93 is complete.

Closes #100

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Sub-task of #93
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

No manual testing required — this is a pure identifier redirection. `Sybgo::get_cron_hooks()` was already delegating to `Cron_Manager::get_hooks()` in the previous sub-issue (#99), so the hook list returned is identical. The only observable behavior change is that `Sybgo::get_cron_hooks()` no longer exists as a callable method.

Verified manually by running `vendor/bin/phpunit --testsuite Unit` after the change: 77 tests executed with the same 5 pre-existing `DashboardWidgetTest` failures and no new regressions.

### How to test

1. Activate the plugin on a WordPress install.
2. Deactivate the plugin — verify all four cron events are unscheduled:
   ```bash
   wp cron event list | grep sybgo
   ```
   Expected: no sybgo cron events listed.
3. Uninstall the plugin (delete from WP Admin) — verify no errors in the PHP log.
4. Re-install and run the full unit suite:
   ```bash
   cd wp-plugin && vendor/bin/phpunit --testsuite Unit
   ```
   Expected: same pass/fail count as the parent branch (5 pre-existing DashboardWidgetTest failures, all others green).

### Affected Features & Quality Assurance Scope

- Plugin deactivation (cron cleanup)
- Plugin uninstall (full data cleanup via `Uninstaller`)

## Technical description

`Sybgo::get_cron_hooks()` introduced in an earlier sub-issue already delegated entirely to `Cron_Manager::get_hooks()`. This PR removes the wrapper and updates its two callers:

- `Sybgo::deactivate()` → `Cron_Manager::get_hooks()`
- `Uninstaller::clear_cron_hooks()` → `Cron_Manager::get_hooks()` (swap `use Sybgo\Sybgo` for `use Sybgo\Cron_Manager`)
- `UninstallerTest` updated to match the new import.

`Cron_Manager::get_hooks()` was already the canonical source (`static` method returning all four hook names). The `development.md` Plugin Uninstall section is updated to reference `Cron_Manager::get_hooks()` instead of the removed method.

See [wp-plugin/docs/development.md](wp-plugin/docs/development.md).

### New dependencies

None.

### Risks

None identified. The hook list is identical — the method being removed was a one-line delegation that added no logic.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A — all items apply and are satisfied. No new tests were written because the existing `UninstallerTest` (updated to use `Cron_Manager`) already exercises the affected code path.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)